### PR TITLE
Adding Vlan manager implementation and test cases

### DIFF
--- a/include/aca_net_config.h
+++ b/include/aca_net_config.h
@@ -56,7 +56,7 @@ class Aca_Net_Config {
 
   int execute_system_command(string cmd_string, ulong &culminative_time);
 
-  // compiler will flag the error when below is called.
+  // compiler will flag error when below is called
   Aca_Net_Config(Aca_Net_Config const &) = delete;
   void operator=(Aca_Net_Config const &) = delete;
 

--- a/include/aca_ovs_programmer.h
+++ b/include/aca_ovs_programmer.h
@@ -25,7 +25,7 @@ class ACA_OVS_Programmer {
   public:
   static ACA_OVS_Programmer &get_instance();
 
-  int setup_bridges();
+  int setup_ovs_bridges_if_need();
 
   int configure_port(const std::string vpc_id, const std::string port_name,
                      const std::string virtual_ip, uint tunnel_id, ulong &culminative_time);

--- a/include/aca_vlan_manager.h
+++ b/include/aca_vlan_manager.h
@@ -40,7 +40,7 @@ class ACA_Vlan_Manager {
   public:
   static ACA_Vlan_Manager &get_instance();
 
-  uint get_vlan_id(string vpc_id);
+  uint get_or_create_vlan_id(string vpc_id);
 
   void add_ovs_port(string vpc_id, string ovs_port);
 

--- a/include/aca_vlan_manager.h
+++ b/include/aca_vlan_manager.h
@@ -1,0 +1,73 @@
+// Copyright 2019 The Alcor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ACA_VLAN_MANAGER_H
+#define ACA_VLAN_MANAGER_H
+
+#include <string>
+#include <list>
+#include <unordered_map>
+#include <mutex>
+#include <atomic>
+
+using namespace ::std;
+
+// TODO: implement a better available internal vlan ids
+// when we have port delete implemented
+static atomic_uint current_available_vlan_id(1);
+
+// Vlan Manager class
+namespace aca_vlan_manager
+{
+struct values {
+  uint vlan_id;
+  list<string> ovs_ports;
+  list<string> outports;
+};
+
+class ACA_Vlan_Manager {
+  public:
+  static ACA_Vlan_Manager &get_instance();
+
+  uint get_vlan_id(string vpc_id);
+
+  void add_ovs_port(string vpc_id, string ovs_port);
+
+  int remove_ovs_port(string vpc_id, string ovs_port);
+
+  void add_outport(string vpc_id, string outport);
+
+  int remove_outport(string vpc_id, string outport);
+
+  int get_outports(string vpc_id, string &outports);
+
+  // compiler will flag error when below is called
+  ACA_Vlan_Manager(ACA_Vlan_Manager const &) = delete;
+  void operator=(ACA_Vlan_Manager const &) = delete;
+
+  private:
+  ACA_Vlan_Manager(){};
+  ~ACA_Vlan_Manager(){};
+
+  unordered_map<std::string, values> vpc_table;
+
+  // mutex for reading and writing to vpc_table
+  mutex vpc_table_mutex;
+
+  bool check_entry_existed_unsafe(string vpc_id);
+
+  void create_entry_unsafe(string vpc_id);
+};
+} // namespace aca_vlan_manager
+#endif // #ifndef ACA_VLAN_MANAGER_H

--- a/include/aca_vlan_manager.h
+++ b/include/aca_vlan_manager.h
@@ -30,9 +30,11 @@ static atomic_uint current_available_vlan_id(1);
 // Vlan Manager class
 namespace aca_vlan_manager
 {
-struct values {
+struct table_entry {
   uint vlan_id;
+  // list of ovs_ports names on this host in the same VPC to share the same internal vlan_id
   list<string> ovs_ports;
+  // list of output (e.g. vxlan) tunnel ports to the neighbor host communication in the same VPC
   list<string> outports;
 };
 
@@ -60,7 +62,7 @@ class ACA_Vlan_Manager {
   ACA_Vlan_Manager(){};
   ~ACA_Vlan_Manager(){};
 
-  unordered_map<std::string, values> vpc_table;
+  unordered_map<std::string, table_entry> vpc_table;
 
   // mutex for reading and writing to vpc_table
   mutex vpc_table_mutex;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     ./dp_abstraction/aca_dataplane_ovs.cpp
     ./net_config/aca_net_config.cpp
     ./ovs/aca_ovs_programmer.cpp
+    ./ovs/aca_vlan_manager.cpp
 )
 FIND_LIBRARY(RDKAFKA rdkafka /usr/lib/x86_64-linux-gnu NO_DEFAULT_PATH)
 FIND_LIBRARY(CPPKAFKA cppkafka /usr/local/lib NO_DEFAULT_PATH)

--- a/src/comm/aca_comm_mgr.cpp
+++ b/src/comm/aca_comm_mgr.cpp
@@ -61,8 +61,6 @@ int Aca_Comm_Manager::deserialize(const cppkafka::Buffer *kafka_buffer, GoalStat
   if (parsed_struct.ParseFromArray(kafka_buffer->get_data(), kafka_buffer->get_size())) {
     ACA_LOG_INFO("Successfully converted kafka buffer to protobuf struct\n");
 
-    this->print_goal_state(parsed_struct);
-
     return EXIT_SUCCESS;
   } else {
     rc = -EXIT_FAILURE;
@@ -80,7 +78,10 @@ int Aca_Comm_Manager::update_goal_state(GoalState &goal_state_message,
 
   ACA_LOG_DEBUG("Starting to update goal state\n");
 
-  ACA_LOG_INFO("Goal state message size is: %lu bytes\n", goal_state_message.ByteSizeLong());
+  ACA_LOG_INFO("!!!Goal state message size is: %lu bytes!!!\n",
+               goal_state_message.ByteSizeLong());
+
+  this->print_goal_state(goal_state_message);
 
   exec_command_rc = Aca_Goal_State_Handler::get_instance().update_vpc_states(
           goal_state_message, gsOperationReply);
@@ -124,8 +125,8 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
   }
 
   for (int i = 0; i < parsed_struct.port_states_size(); i++) {
-    fprintf(stdout, "parsed_struct.port_states(%d).operation_type(): %d\n", i,
-            parsed_struct.port_states(i).operation_type());
+    fprintf(stdout, "parsed_struct.port_states(%d).operation_type(): %s\n", i,
+            aca_get_operation_string(parsed_struct.port_states(i).operation_type()));
 
     PortConfiguration current_PortConfiguration =
             parsed_struct.port_states(i).configuration();
@@ -196,8 +197,8 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
   }
 
   for (int i = 0; i < parsed_struct.subnet_states_size(); i++) {
-    fprintf(stdout, "parsed_struct.subnet_states(%d).operation_type(): %d\n", i,
-            parsed_struct.subnet_states(i).operation_type());
+    fprintf(stdout, "parsed_struct.subnet_states(%d).operation_type(): %s\n", i,
+            aca_get_operation_string(parsed_struct.subnet_states(i).operation_type()));
 
     SubnetConfiguration current_SubnetConfiguration =
             parsed_struct.subnet_states(i).configuration();
@@ -243,8 +244,8 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
   }
 
   for (int i = 0; i < parsed_struct.vpc_states_size(); i++) {
-    fprintf(stdout, "parsed_struct.vpc_states(%d).operation_type(): %d\n", i,
-            parsed_struct.vpc_states(i).operation_type());
+    fprintf(stdout, "parsed_struct.vpc_states(%d).operation_type(): %s\n", i,
+            aca_get_operation_string(parsed_struct.vpc_states(i).operation_type()));
 
     VpcConfiguration current_VpcConfiguration =
             parsed_struct.vpc_states(i).configuration();

--- a/src/comm/aca_comm_mgr.cpp
+++ b/src/comm/aca_comm_mgr.cpp
@@ -78,7 +78,7 @@ int Aca_Comm_Manager::update_goal_state(GoalState &goal_state_message,
 
   ACA_LOG_DEBUG("Starting to update goal state\n");
 
-  ACA_LOG_INFO("!!!Goal state message size is: %lu bytes!!!\n",
+  ACA_LOG_INFO("[METRICS] Goal state message size is: %lu bytes\n",
                goal_state_message.ByteSizeLong());
 
   this->print_goal_state(goal_state_message);
@@ -112,7 +112,7 @@ int Aca_Comm_Manager::update_goal_state(GoalState &goal_state_message,
 
   g_total_update_GS_time += message_total_operation_time;
 
-  ACA_LOG_INFO("Elapsed time for message total operation took: %ld nanoseconds or %ld milliseconds.\n",
+  ACA_LOG_INFO("[METRICS] Elapsed time for message total operation took: %ld nanoseconds or %ld milliseconds\n",
                message_total_operation_time, message_total_operation_time / 1000000);
 
   return rc;

--- a/src/dp_abstraction/aca_dataplane_ovs.cpp
+++ b/src/dp_abstraction/aca_dataplane_ovs.cpp
@@ -69,7 +69,7 @@ namespace aca_dataplane_ovs
 int ACA_Dataplane_OVS::initialize()
 {
   // TODO: improve the logging system, and add logging to this module
-  return ACA_OVS_Programmer::get_instance().setup_bridges();
+  return ACA_OVS_Programmer::get_instance().setup_ovs_bridges_if_need();
 }
 
 int ACA_Dataplane_OVS::update_vpc_state_workitem(const VpcState current_VpcState,

--- a/src/ovs/aca_ovs_programmer.cpp
+++ b/src/ovs/aca_ovs_programmer.cpp
@@ -140,7 +140,10 @@ int ACA_OVS_Programmer::configure_port(const string vpc_id, const string port_na
   }
 
   // TODO: if ovs_port already exist in vlan manager, that means it is a duplicated
-  // port CREATE operation, return error.
+  // port CREATE operation, we have the following options to handle it:
+  // 1. Reject call with error message
+  // 2. No ops with warning message
+  // 3. Do it regardless => if there is anything wrong, controller's fault :-)
 
   // use vpc_id to query vlan_manager to lookup an existing vpc_id entry to get its
   // internal vlan id or to create a new vpc_id entry to get a new internal vlan id

--- a/src/ovs/aca_ovs_programmer.cpp
+++ b/src/ovs/aca_ovs_programmer.cpp
@@ -95,8 +95,8 @@ int ACA_OVS_Programmer::setup_ovs_bridges_if_need()
   } else {
     // case 3: only one of the br-int or br-tun is there,
     // Invalid environment so return an error
-    ACA_LOG_ERROR("Invalid environment br-int=%d and br-tun=%d, cannot proceed\n",
-                  br_int_existed, br_tun_existed);
+    ACA_LOG_CRIT("Invalid environment br-int=%d and br-tun=%d, cannot proceed\n",
+                 br_int_existed, br_tun_existed);
     overall_rc = EXIT_FAILURE;
   }
 
@@ -138,6 +138,9 @@ int ACA_OVS_Programmer::configure_port(const string vpc_id, const string port_na
   if (overall_rc != EXIT_SUCCESS) {
     throw std::runtime_error("Invalid environment with br-int and br-tun");
   }
+
+  // TODO: if ovs_port already exist in vlan manager, that means it is a duplicated
+  // port CREATE operation, return error.
 
   // use vpc_id to query vlan_manager to lookup an existing vpc_id entry to get its
   // internal vlan id or to create a new vpc_id entry to get a new internal vlan id

--- a/src/ovs/aca_ovs_programmer.cpp
+++ b/src/ovs/aca_ovs_programmer.cpp
@@ -59,19 +59,15 @@ int ACA_OVS_Programmer::setup_ovs_bridges_if_need()
 
   overall_rc = EXIT_SUCCESS;
 
-  // case 1: both br-int and br-tun exist
   if (br_int_existed && br_int_existed) {
+    // case 1: both br-int and br-tun exist
     // nothing to do
-  }
-
-  // case 2: both br-int and br-tun not there, create them
-  else if (!br_int_existed && !br_int_existed) {
+  } else if (!br_int_existed && !br_int_existed) {
+    // case 2: both br-int and br-tun not there, create them
     // create br-int and br-tun bridges
     execute_ovsdb_command("add-br br-int", not_care_culminative_time, overall_rc);
 
     execute_ovsdb_command("add-br br-tun", not_care_culminative_time, overall_rc);
-
-    // execute_openflow_command("del-flows br-tun", not_care_culminative_time, overall_rc);
 
     // create and connect the patch ports between br-int and br-tun
     execute_ovsdb_command("add-port br-int patch-tun", not_care_culminative_time, overall_rc);
@@ -96,13 +92,11 @@ int ACA_OVS_Programmer::setup_ovs_bridges_if_need()
 
     execute_openflow_command("add-flow br-tun \"table=2, priority=0 actions=resubmit(,22)\"",
                              not_care_culminative_time, overall_rc);
-
   } else {
     // case 3: only one of the br-int or br-tun is there,
     // Invalid environment so return an error
     ACA_LOG_ERROR("Invalid environment br-int=%d and br-tun=%d, cannot proceed\n",
                   br_int_existed, br_tun_existed);
-
     overall_rc = EXIT_FAILURE;
   }
 
@@ -147,7 +141,7 @@ int ACA_OVS_Programmer::configure_port(const string vpc_id, const string port_na
 
   // use vpc_id to query vlan_manager to lookup an existing vpc_id entry to get its
   // internal vlan id or to create a new vpc_id entry to get a new internal vlan id
-  int internal_vlan_id = ACA_Vlan_Manager::get_instance().get_vlan_id(vpc_id);
+  int internal_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(vpc_id);
 
   ACA_Vlan_Manager::get_instance().add_ovs_port(vpc_id, port_name);
 
@@ -220,7 +214,7 @@ int ACA_OVS_Programmer::create_update_neighbor_port(const string vpc_id,
 
   // use vpc_id to query vlan_manager to lookup an existing vpc_id entry to get its
   // internal vlan id or to create a new vpc_id entry to get a new internal vlan id
-  int internal_vlan_id = ACA_Vlan_Manager::get_instance().get_vlan_id(vpc_id);
+  int internal_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(vpc_id);
 
   ACA_Vlan_Manager::get_instance().add_outport(vpc_id, outport_name);
 

--- a/src/ovs/aca_vlan_manager.cpp
+++ b/src/ovs/aca_vlan_manager.cpp
@@ -1,0 +1,205 @@
+// Copyright 2019 The Alcor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "aca_log.h"
+#include "aca_vlan_manager.h"
+#include <errno.h>
+#include <algorithm>
+
+namespace aca_vlan_manager
+{
+ACA_Vlan_Manager &ACA_Vlan_Manager::get_instance()
+{
+  // Instance is destroyed when program exits.
+  // It is instantiated on first use.
+  static ACA_Vlan_Manager instance;
+  return instance;
+}
+
+// unsafe function, needs to be called inside vpc_table_mutex lock
+bool ACA_Vlan_Manager::check_entry_existed_unsafe(string vpc_id)
+{
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::check_entry_existed_unsafe ---> Entering\n");
+
+  std::unordered_map<std::string, values>::const_iterator found = vpc_table.find(vpc_id);
+
+  // found would be equal to vpc_table.end() if entry is not there
+  bool entry_existed = (found != vpc_table.end());
+
+  ACA_LOG_DEBUG("ACA_OVS_Programmer::check_entry_existed_unsafe <--- Exiting\n");
+
+  return entry_existed;
+}
+
+// unsafe function, needs to be called inside vpc_table_mutex lock
+// this function assumes there is no existing entry for vpc_id
+void ACA_Vlan_Manager::create_entry_unsafe(string vpc_id)
+{
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::create_entry_unsafe ---> Entering\n");
+
+  values new_values;
+  new_values.vlan_id = current_available_vlan_id.load();
+  current_available_vlan_id++;
+
+  vpc_table.emplace(vpc_id, new_values);
+
+  ACA_LOG_DEBUG("ACA_OVS_Programmer::create_entry_unsafe <--- Exiting\n");
+}
+
+uint ACA_Vlan_Manager::get_vlan_id(string vpc_id)
+{
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::acquire_vlan_id ---> Entering\n");
+
+  // -----critical section starts-----
+  vpc_table_mutex.lock();
+  if (!check_entry_existed_unsafe(vpc_id)) {
+    create_entry_unsafe(vpc_id);
+  }
+  uint acquired_vlan_id = vpc_table[vpc_id].vlan_id;
+  vpc_table_mutex.unlock();
+  // -----critical section ends-----
+
+  ACA_LOG_DEBUG("ACA_OVS_Programmer::acquire_vlan_id <--- Exiting\n");
+
+  return acquired_vlan_id;
+}
+
+void ACA_Vlan_Manager::add_ovs_port(string vpc_id, string ovs_port)
+{
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::add_ovs_port ---> Entering\n");
+
+  // -----critical section starts-----
+  vpc_table_mutex.lock();
+  if (!check_entry_existed_unsafe(vpc_id)) {
+    create_entry_unsafe(vpc_id);
+  }
+  vpc_table[vpc_id].ovs_ports.push_back(ovs_port);
+  vpc_table_mutex.unlock();
+  // -----critical section ends-----
+
+  ACA_LOG_DEBUG("ACA_OVS_Programmer::add_ovs_port <--- Exiting\n");
+}
+
+// called when a port associated with a vpc on this host is deleted
+int ACA_Vlan_Manager::remove_ovs_port(string vpc_id, string ovs_port)
+{
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::remove_ovs_port ---> Entering\n");
+
+  int overall_rc;
+
+  // -----critical section starts-----
+  vpc_table_mutex.lock();
+  if (!check_entry_existed_unsafe(vpc_id)) {
+    ACA_LOG_ERROR("vpc_id %s not find in vpc_table\n", vpc_id.c_str());
+    overall_rc = ENOENT;
+  } else {
+    vpc_table[vpc_id].ovs_ports.remove(ovs_port);
+    // clean up the vpc_table entry if there is no port assoicated
+    if (vpc_table[vpc_id].ovs_ports.empty()) {
+      if (vpc_table.erase(vpc_id) == 1) {
+        ACA_LOG_INFO("Successfuly cleaned up entry for vpc_id %s\n", vpc_id.c_str());
+        overall_rc = EXIT_SUCCESS;
+      } else {
+        ACA_LOG_ERROR("Failed to clean up entry for vpc_id %s\n", vpc_id.c_str());
+        overall_rc = EXIT_FAILURE;
+      }
+    }
+  }
+  vpc_table_mutex.unlock();
+  // -----critical section ends-----
+
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::remove_ovs_port <--- Exiting, overall_rc = %d\n", overall_rc);
+
+  return overall_rc;
+}
+
+void ACA_Vlan_Manager::add_outport(string vpc_id, string outport)
+{
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::add_outport ---> Entering\n");
+
+  // -----critical section starts-----
+  vpc_table_mutex.lock();
+  if (!check_entry_existed_unsafe(vpc_id)) {
+    create_entry_unsafe(vpc_id);
+    vpc_table[vpc_id].outports.push_back(outport);
+  } else {
+    auto current_outports = vpc_table[vpc_id].outports;
+    auto it = std::find(current_outports.begin(), current_outports.end(), outport);
+    if (it == current_outports.end()) {
+      vpc_table[vpc_id].outports.push_back(outport);
+    } // else nothing to do if outport is already there
+  }
+  vpc_table_mutex.unlock();
+  // -----critical section ends-----
+
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::add_outport <--- Exiting\n");
+}
+
+// called when a neighbor info is deleted
+int ACA_Vlan_Manager::remove_outport(string vpc_id, string outport)
+{
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::remove_outport ---> Entering\n");
+
+  int overall_rc;
+
+  // -----critical section starts-----
+  vpc_table_mutex.lock();
+  if (!check_entry_existed_unsafe(vpc_id)) {
+    ACA_LOG_ERROR("vpc_id %s not find in vpc_table\n", vpc_id.c_str());
+    overall_rc = ENOENT;
+  } else {
+    vpc_table[vpc_id].outports.remove(outport);
+    overall_rc = EXIT_SUCCESS;
+  }
+  vpc_table_mutex.unlock();
+  // -----critical section ends-----
+
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::remove_outport <--- Exiting, overall_rc = %d\n", overall_rc);
+
+  return overall_rc;
+}
+
+int ACA_Vlan_Manager::get_outports(string vpc_id, string &outports)
+{
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::get_outports ---> Entering\n");
+
+  int overall_rc;
+
+  // -----critical section starts-----
+  vpc_table_mutex.lock();
+  if (!check_entry_existed_unsafe(vpc_id)) {
+    ACA_LOG_ERROR("vpc_id %s not find in vpc_table\n", vpc_id.c_str());
+    overall_rc = ENOENT;
+  } else {
+    outports.clear();
+    auto current_outports = vpc_table[vpc_id].outports;
+
+    for (auto it = current_outports.begin(); it != current_outports.end(); it++) {
+      if (it == current_outports.begin()) {
+        outports += *it;
+      } else {
+        outports += ' ' + *it;
+      }
+    }
+    overall_rc = EXIT_SUCCESS;
+  }
+  vpc_table_mutex.unlock();
+  // -----critical section ends-----
+
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::get_outports <--- Exiting, overall_rc = %d\n", overall_rc);
+
+  return overall_rc;
+}
+
+} // namespace aca_vlan_manager

--- a/src/ovs/aca_vlan_manager.cpp
+++ b/src/ovs/aca_vlan_manager.cpp
@@ -32,7 +32,8 @@ bool ACA_Vlan_Manager::check_entry_existed_unsafe(string vpc_id)
 {
   ACA_LOG_DEBUG("ACA_Vlan_Manager::check_entry_existed_unsafe ---> Entering\n");
 
-  std::unordered_map<std::string, values>::const_iterator found = vpc_table.find(vpc_id);
+  std::unordered_map<std::string, table_entry>::const_iterator found =
+          vpc_table.find(vpc_id);
 
   // found would be equal to vpc_table.end() if entry is not there
   bool entry_existed = (found != vpc_table.end());
@@ -48,11 +49,11 @@ void ACA_Vlan_Manager::create_entry_unsafe(string vpc_id)
 {
   ACA_LOG_DEBUG("ACA_Vlan_Manager::create_entry_unsafe ---> Entering\n");
 
-  values new_values;
-  new_values.vlan_id = current_available_vlan_id.load();
+  table_entry new_table_entry;
+  new_table_entry.vlan_id = current_available_vlan_id.load();
   current_available_vlan_id++;
 
-  vpc_table.emplace(vpc_id, new_values);
+  vpc_table.emplace(vpc_id, new_table_entry);
 
   ACA_LOG_DEBUG("ACA_OVS_Programmer::create_entry_unsafe <--- Exiting\n");
 }

--- a/src/ovs/aca_vlan_manager.cpp
+++ b/src/ovs/aca_vlan_manager.cpp
@@ -57,7 +57,7 @@ void ACA_Vlan_Manager::create_entry_unsafe(string vpc_id)
   ACA_LOG_DEBUG("ACA_OVS_Programmer::create_entry_unsafe <--- Exiting\n");
 }
 
-uint ACA_Vlan_Manager::get_vlan_id(string vpc_id)
+uint ACA_Vlan_Manager::get_or_create_vlan_id(string vpc_id)
 {
   ACA_LOG_DEBUG("ACA_Vlan_Manager::acquire_vlan_id ---> Entering\n");
 

--- a/test/gtest/aca_tests.cpp
+++ b/test/gtest/aca_tests.cpp
@@ -37,15 +37,24 @@ static char VALID_STRING[] = "VALID_STRING";
 static char DEFAULT_MTU[] = "9000";
 
 static string project_id = "99d9d709-8478-4b46-9f3f-000000000000";
-static string vpc_id = "99d9d709-8478-4b46-9f3f-111111111111";
-static string subnet_id = "99d9d709-8478-4b46-9f3f-222222222222";
-static string port_name_1 = "tap-33333333";
-static string port_name_2 = "tap-44444444";
+static string vpc_id_1 = "1b08a5bc-b718-11ea-b3de-111111111111";
+static string vpc_id_2 = "1b08a5bc-b718-11ea-b3de-222222222222";
+static string subnet_id_1 = "27330ae4-b718-11ea-b3de-111111111111";
+static string subnet_id_2 = "27330ae4-b718-11ea-b3de-222222222222";
+static string port_name_1 = "tap-11111111";
+static string port_name_2 = "tap-22222222";
+static string port_name_3 = "tap-33333333";
+static string port_name_4 = "tap-44444444";
 static string vmac_address_1 = "fa:16:3e:d7:f2:6c";
 static string vmac_address_2 = "fa:16:3e:d7:f2:6d";
+static string vmac_address_3 = "fa:16:3e:d7:f2:6e";
+static string vmac_address_4 = "fa:16:3e:d7:f2:6f";
 static string vip_address_1 = "10.0.0.1";
-static string vip_address_2 = "10.0.0.2";
-static string remote_ip_1 = "172.0.0.2";
+static string vip_address_2 = "10.0.1.2";
+static string vip_address_3 = "10.0.0.3";
+static string vip_address_4 = "10.0.1.4";
+static string remote_ip_1 = "172.17.0.2";
+static string remote_ip_2 = "172.17.0.3";
 static NetworkType vxlan_type = NetworkType::VXLAN;
 
 // Global variables
@@ -61,6 +70,20 @@ bool g_transitd_loaded = false;
 
 using aca_net_config::Aca_Net_Config;
 using aca_ovs_programmer::ACA_OVS_Programmer;
+
+// TODO: setup bridge when br-int is up and br-tun is gone
+
+// TODO: invalid IP
+
+// TODO: invalid mac
+
+// TODO: tunnel ID
+
+// TODO: subnet info not available
+
+// TODO: neighbor invalid IP
+
+// TODO: neighbor invalid mac
 
 static void aca_cleanup()
 {
@@ -96,13 +119,13 @@ static void aca_test_create_default_port_state(PortState *new_port_states)
   // PortConfiguration_builder->set_network_type(NetworkType::VXLAN); // should default to VXLAN
 
   PortConfiguration_builder->set_project_id(project_id);
-  PortConfiguration_builder->set_vpc_id(vpc_id);
+  PortConfiguration_builder->set_vpc_id(vpc_id_1);
   PortConfiguration_builder->set_name(port_name_1);
   PortConfiguration_builder->set_mac_address(vmac_address_1);
   PortConfiguration_builder->set_admin_state_up(true);
 
   PortConfiguration_FixedIp *FixedIp_builder = PortConfiguration_builder->add_fixed_ips();
-  FixedIp_builder->set_subnet_id(subnet_id);
+  FixedIp_builder->set_subnet_id(subnet_id_1);
   FixedIp_builder->set_ip_address(vip_address_1);
 
   PortConfiguration_SecurityGroupId *SecurityGroup_builder =
@@ -119,8 +142,8 @@ static void aca_test_create_default_subnet_state(SubnetState *new_subnet_states)
   SubnetConiguration_builder->set_format_version(1);
   SubnetConiguration_builder->set_revision_number(1);
   SubnetConiguration_builder->set_project_id(project_id);
-  SubnetConiguration_builder->set_vpc_id(vpc_id);
-  SubnetConiguration_builder->set_id(subnet_id);
+  SubnetConiguration_builder->set_vpc_id(vpc_id_1);
+  SubnetConiguration_builder->set_id(subnet_id_1);
   SubnetConiguration_builder->set_cidr("10.0.0.0/24");
   SubnetConiguration_builder->set_tunnel_id(20);
 }
@@ -173,12 +196,12 @@ TEST(ovs_dataplane_test_cases, 2_ports_config_test_traffic)
 
   // create two ports (using demo mode) and configure them
   overall_rc = ACA_OVS_Programmer::get_instance().configure_port(
-          vpc_id, port_name_1, vip_address_1 + prefix_len, 20, not_care_culminative_time);
+          vpc_id_1, port_name_1, vip_address_1 + prefix_len, 20, not_care_culminative_time);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
   overall_rc = ACA_OVS_Programmer::get_instance().configure_port(
-          vpc_id, port_name_2, vip_address_2 + prefix_len, 20, not_care_culminative_time);
+          vpc_id_1, port_name_2, vip_address_2 + prefix_len, 20, not_care_culminative_time);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
@@ -209,7 +232,7 @@ TEST(ovs_dataplane_test_cases, 2_ports_config_test_traffic)
 
   // insert neighbor info
   overall_rc = ACA_OVS_Programmer::get_instance().create_update_neighbor_port(
-          vpc_id, vxlan_type, remote_ip_1, 20, not_care_culminative_time);
+          vpc_id_1, vxlan_type, remote_ip_1, 20, not_care_culminative_time);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
@@ -241,14 +264,6 @@ TEST(ovs_dataplane_test_cases, 2_ports_config_test_traffic)
   EXPECT_NE(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 }
-
-// TODO: invalid IP
-
-// TODO: invalid mac
-
-// TODO: tunnel ID
-
-// TODO: subnet info not available
 
 TEST(ovs_dataplane_test_cases, 1_port_CREATE)
 {
@@ -331,7 +346,8 @@ TEST(ovs_dataplane_test_cases, 1_port_NEIGHBOR_CREATE_UPDATE)
   PortConfiguration_builder->set_network_type(vxlan_type);
 
   PortConfiguration_builder->set_project_id(project_id);
-  PortConfiguration_builder->set_vpc_id(vpc_id);
+  PortConfiguration_builder->set_vpc_id(vpc_id_1);
+  PortConfiguration_builder->set_mac_address(vmac_address_3);
   PortConfiguration_builder->set_admin_state_up(true);
 
   PortConfiguration_HostInfo *portConfig_HostInfoBuilder(new PortConfiguration_HostInfo);
@@ -339,7 +355,8 @@ TEST(ovs_dataplane_test_cases, 1_port_NEIGHBOR_CREATE_UPDATE)
   PortConfiguration_builder->set_allocated_host_info(portConfig_HostInfoBuilder);
 
   PortConfiguration_FixedIp *FixedIp_builder = PortConfiguration_builder->add_fixed_ips();
-  FixedIp_builder->set_subnet_id(subnet_id);
+  FixedIp_builder->set_ip_address(vip_address_3);
+  FixedIp_builder->set_subnet_id(subnet_id_1);
 
   // fill in subnet state structs
   aca_test_create_default_subnet_state(new_subnet_states);
@@ -414,7 +431,8 @@ TEST(ovs_dataplane_test_cases, 1_port_CREATE_plus_NEIGHBOR_CREATE_UPDATE)
   PortConfiguration_builder2->set_network_type(vxlan_type);
 
   PortConfiguration_builder2->set_project_id(project_id);
-  PortConfiguration_builder2->set_vpc_id(vpc_id);
+  PortConfiguration_builder2->set_vpc_id(vpc_id_1);
+  PortConfiguration_builder2->set_mac_address(vmac_address_3);
   PortConfiguration_builder2->set_admin_state_up(true);
 
   PortConfiguration_HostInfo *portConfig_HostInfoBuilder2(new PortConfiguration_HostInfo);
@@ -423,7 +441,8 @@ TEST(ovs_dataplane_test_cases, 1_port_CREATE_plus_NEIGHBOR_CREATE_UPDATE)
 
   PortConfiguration_FixedIp *FixedIp_builder2 =
           PortConfiguration_builder2->add_fixed_ips();
-  FixedIp_builder2->set_subnet_id(subnet_id);
+  FixedIp_builder2->set_subnet_id(subnet_id_1);
+  FixedIp_builder2->set_ip_address(vip_address_3);
 
   // delete br-int and br-tun bridges
   ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
@@ -464,6 +483,7 @@ TEST(ovs_dataplane_test_cases, 1_port_CREATE_plus_NEIGHBOR_CREATE_UPDATE)
 
   // free the allocated configurations since we are done with it now
   new_port_states->clear_configuration();
+  new_port_neighbor_states->clear_configuration();
   new_subnet_states->clear_configuration();
 
   // delete br-int and br-tun bridges
@@ -498,13 +518,13 @@ TEST(ovs_dataplane_test_cases, 2_ports_CREATE_test_traffic)
   // PortConfiguration_builder->set_network_type(NetworkType::VXLAN); // should default to VXLAN
 
   PortConfiguration_builder->set_project_id(project_id);
-  PortConfiguration_builder->set_vpc_id(vpc_id);
+  PortConfiguration_builder->set_vpc_id(vpc_id_1);
   PortConfiguration_builder->set_name(port_name_1);
   PortConfiguration_builder->set_mac_address(vmac_address_1);
   PortConfiguration_builder->set_admin_state_up(true);
 
   PortConfiguration_FixedIp *FixedIp_builder = PortConfiguration_builder->add_fixed_ips();
-  FixedIp_builder->set_subnet_id(subnet_id);
+  FixedIp_builder->set_subnet_id(subnet_id_1);
   FixedIp_builder->set_ip_address(vip_address_1);
 
   PortConfiguration_SecurityGroupId *SecurityGroup_builder =
@@ -582,6 +602,343 @@ TEST(ovs_dataplane_test_cases, 2_ports_CREATE_test_traffic)
           "del-br br-tun", not_care_culminative_time, overall_rc);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
+}
+
+TEST(ovs_dataplane_test_cases, DISABLED_2_ports_CREATE_test_traffic_MASTER)
+{
+  ulong not_care_culminative_time = 0;
+  string cmd_string;
+  int overall_rc;
+
+  GoalState GoalState_builder;
+  PortState *new_port_states = GoalState_builder.add_port_states();
+  SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
+
+  new_port_states->set_operation_type(OperationType::CREATE);
+
+  // fill in port state structs for port 1
+  PortConfiguration *PortConfiguration_builder = new_port_states->mutable_configuration();
+  PortConfiguration_builder->set_format_version(1);
+  PortConfiguration_builder->set_revision_number(1);
+  PortConfiguration_builder->set_message_type(MessageType::FULL);
+  // PortConfiguration_builder->set_network_type(NetworkType::VXLAN); // should default to VXLAN
+
+  PortConfiguration_builder->set_project_id(project_id);
+  PortConfiguration_builder->set_vpc_id(vpc_id_1);
+  PortConfiguration_builder->set_name(port_name_1);
+  PortConfiguration_builder->set_mac_address(vmac_address_1);
+  PortConfiguration_builder->set_admin_state_up(true);
+
+  PortConfiguration_FixedIp *FixedIp_builder = PortConfiguration_builder->add_fixed_ips();
+  FixedIp_builder->set_subnet_id(subnet_id_1);
+  FixedIp_builder->set_ip_address(vip_address_1);
+
+  PortConfiguration_SecurityGroupId *SecurityGroup_builder =
+          PortConfiguration_builder->add_security_group_ids();
+  SecurityGroup_builder->set_id("1");
+
+  // fill in subnet state structs
+  new_subnet_states->set_operation_type(OperationType::INFO);
+
+  SubnetConfiguration *SubnetConiguration_builder =
+          new_subnet_states->mutable_configuration();
+  SubnetConiguration_builder->set_format_version(1);
+  SubnetConiguration_builder->set_revision_number(1);
+  SubnetConiguration_builder->set_project_id(project_id);
+  SubnetConiguration_builder->set_vpc_id(vpc_id_1);
+  SubnetConiguration_builder->set_id(subnet_id_1);
+  SubnetConiguration_builder->set_cidr("10.0.0.0/24");
+  SubnetConiguration_builder->set_tunnel_id(20);
+
+  // add a new port state with NEIGHBOR_CREATE_UPDATE
+  PortState *new_port_neighbor_states = GoalState_builder.add_port_states();
+
+  new_port_neighbor_states->set_operation_type(OperationType::NEIGHBOR_CREATE_UPDATE);
+
+  // fill in port state structs for NEIGHBOR_CREATE_UPDATE for port 3
+  PortConfiguration *PortConfiguration_builder2 =
+          new_port_neighbor_states->mutable_configuration();
+  PortConfiguration_builder2->set_format_version(2);
+  PortConfiguration_builder2->set_revision_number(2);
+  PortConfiguration_builder2->set_message_type(MessageType::DELTA);
+  PortConfiguration_builder2->set_network_type(vxlan_type);
+
+  PortConfiguration_builder2->set_project_id(project_id);
+  PortConfiguration_builder2->set_vpc_id(vpc_id_1);
+  PortConfiguration_builder2->set_mac_address(vmac_address_3);
+  PortConfiguration_builder2->set_admin_state_up(true);
+
+  PortConfiguration_HostInfo *portConfig_HostInfoBuilder2(new PortConfiguration_HostInfo);
+  portConfig_HostInfoBuilder2->set_ip_address(remote_ip_2);
+  PortConfiguration_builder2->set_allocated_host_info(portConfig_HostInfoBuilder2);
+
+  PortConfiguration_FixedIp *FixedIp_builder2 =
+          PortConfiguration_builder2->add_fixed_ips();
+  FixedIp_builder2->set_subnet_id(subnet_id_1);
+  FixedIp_builder2->set_ip_address(vip_address_3);
+
+  // delete br-int and br-tun bridges
+  ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-int", not_care_culminative_time, overall_rc);
+
+  ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-tun", not_care_culminative_time, overall_rc);
+
+  // set demo mode
+  bool previous_demo_mode = g_demo_mode;
+  g_demo_mode = true;
+
+  // create a new port 1 + port 3 neighbor in demo mode
+  GoalStateOperationReply gsOperationalReply;
+
+  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
+          GoalState_builder, gsOperationalReply);
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // check to ensure the port 1 is created and setup correctly
+  ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
+          "get Interface " + port_name_1 + " ofport", not_care_culminative_time, overall_rc);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // setup the configuration for port 2
+  PortConfiguration_builder->set_vpc_id(vpc_id_2);
+  PortConfiguration_builder->set_name(port_name_2);
+  PortConfiguration_builder->set_mac_address(vmac_address_2);
+  FixedIp_builder->set_ip_address(vip_address_2);
+  FixedIp_builder->set_subnet_id(subnet_id_2);
+
+  // fill in subnet state structs
+  SubnetConiguration_builder->set_vpc_id(vpc_id_2);
+  SubnetConiguration_builder->set_id(subnet_id_2);
+  SubnetConiguration_builder->set_cidr("10.0.1.0/24");
+  SubnetConiguration_builder->set_tunnel_id(30);
+
+  // fill in port state structs for NEIGHBOR_CREATE_UPDATE for port 4
+  PortConfiguration_builder2->set_vpc_id(vpc_id_2);
+  PortConfiguration_builder2->set_mac_address(vmac_address_4);
+  FixedIp_builder2->set_subnet_id(subnet_id_2);
+  FixedIp_builder2->set_ip_address(vip_address_4);
+
+  // create a new port 2 + port 4 neighbor in demo mode
+  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
+          GoalState_builder, gsOperationalReply);
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // restore demo mode
+  g_demo_mode = previous_demo_mode;
+
+  // check to ensure the port 2 is created and setup correctly
+  ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
+          "get Interface " + port_name_2 + " ofport", not_care_culminative_time, overall_rc);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // test traffic between the two newly created ports
+  cmd_string = "ping -I " + vip_address_1 + " -c1 " + vip_address_2;
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  cmd_string = "ping -I " + vip_address_2 + " -c1 " + vip_address_1;
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // test valid traffic from master to slave
+  cmd_string = "ping -I " + vip_address_1 + " -c1 " + vip_address_3;
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  cmd_string = "ping -I " + vip_address_2 + " -c1 " + vip_address_4;
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // test invalid traffic from master to slave with different subnets
+  cmd_string = "ping -I " + vip_address_1 + " -c1 " + vip_address_4;
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
+  EXPECT_NE(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  cmd_string = "ping -I " + vip_address_2 + " -c1 " + vip_address_3;
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
+  EXPECT_NE(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // clean up
+
+  // free the allocated configurations since we are done with it now
+  new_port_states->clear_configuration();
+  new_port_neighbor_states->clear_configuration();
+  new_subnet_states->clear_configuration();
+
+  // delete br-int and br-tun bridges
+  ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-int", not_care_culminative_time, overall_rc);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-tun", not_care_culminative_time, overall_rc);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+}
+
+TEST(ovs_dataplane_test_cases, DISABLED_2_ports_CREATE_test_traffic_SLAVE)
+{
+  ulong not_care_culminative_time = 0;
+  string cmd_string;
+  int overall_rc;
+
+  GoalState GoalState_builder;
+  PortState *new_port_states = GoalState_builder.add_port_states();
+  SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
+
+  new_port_states->set_operation_type(OperationType::CREATE);
+
+  // fill in port state structs for port 3
+  PortConfiguration *PortConfiguration_builder = new_port_states->mutable_configuration();
+  PortConfiguration_builder->set_format_version(1);
+  PortConfiguration_builder->set_revision_number(1);
+  PortConfiguration_builder->set_message_type(MessageType::FULL);
+  // PortConfiguration_builder->set_network_type(NetworkType::VXLAN); // should default to VXLAN
+
+  PortConfiguration_builder->set_project_id(project_id);
+  PortConfiguration_builder->set_vpc_id(vpc_id_1);
+  PortConfiguration_builder->set_name(port_name_3);
+  PortConfiguration_builder->set_mac_address(vmac_address_3);
+  PortConfiguration_builder->set_admin_state_up(true);
+
+  PortConfiguration_FixedIp *FixedIp_builder = PortConfiguration_builder->add_fixed_ips();
+  FixedIp_builder->set_subnet_id(subnet_id_1);
+  FixedIp_builder->set_ip_address(vip_address_3);
+
+  PortConfiguration_SecurityGroupId *SecurityGroup_builder =
+          PortConfiguration_builder->add_security_group_ids();
+  SecurityGroup_builder->set_id("1");
+
+  // fill in subnet state structs
+  new_subnet_states->set_operation_type(OperationType::INFO);
+
+  SubnetConfiguration *SubnetConiguration_builder =
+          new_subnet_states->mutable_configuration();
+  SubnetConiguration_builder->set_format_version(1);
+  SubnetConiguration_builder->set_revision_number(1);
+  SubnetConiguration_builder->set_project_id(project_id);
+  SubnetConiguration_builder->set_vpc_id(vpc_id_1);
+  SubnetConiguration_builder->set_id(subnet_id_1);
+  SubnetConiguration_builder->set_cidr("10.0.0.0/24");
+  SubnetConiguration_builder->set_tunnel_id(20);
+
+  // add a new port state with NEIGHBOR_CREATE_UPDATE
+  PortState *new_port_neighbor_states = GoalState_builder.add_port_states();
+
+  new_port_neighbor_states->set_operation_type(OperationType::NEIGHBOR_CREATE_UPDATE);
+
+  // fill in port state structs for NEIGHBOR_CREATE_UPDATE for port 1
+  PortConfiguration *PortConfiguration_builder2 =
+          new_port_neighbor_states->mutable_configuration();
+  PortConfiguration_builder2->set_format_version(2);
+  PortConfiguration_builder2->set_revision_number(2);
+  PortConfiguration_builder2->set_message_type(MessageType::DELTA);
+  PortConfiguration_builder2->set_network_type(vxlan_type);
+
+  PortConfiguration_builder2->set_project_id(project_id);
+  PortConfiguration_builder2->set_vpc_id(vpc_id_1);
+  PortConfiguration_builder2->set_mac_address(vmac_address_1);
+  PortConfiguration_builder2->set_admin_state_up(true);
+
+  PortConfiguration_HostInfo *portConfig_HostInfoBuilder2(new PortConfiguration_HostInfo);
+  portConfig_HostInfoBuilder2->set_ip_address(remote_ip_1);
+  PortConfiguration_builder2->set_allocated_host_info(portConfig_HostInfoBuilder2);
+
+  PortConfiguration_FixedIp *FixedIp_builder2 =
+          PortConfiguration_builder2->add_fixed_ips();
+  FixedIp_builder2->set_subnet_id(subnet_id_1);
+  FixedIp_builder2->set_ip_address(vip_address_1);
+
+  // delete br-int and br-tun bridges
+  ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-int", not_care_culminative_time, overall_rc);
+
+  ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-tun", not_care_culminative_time, overall_rc);
+
+  // set demo mode
+  bool previous_demo_mode = g_demo_mode;
+  g_demo_mode = true;
+
+  // create a new port 3 + port 1 neighbor in demo mode
+  GoalStateOperationReply gsOperationalReply;
+
+  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
+          GoalState_builder, gsOperationalReply);
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // check to ensure the port 3 is created and setup correctly
+  ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
+          "get Interface " + port_name_3 + " ofport", not_care_culminative_time, overall_rc);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // setup the configuration for port 4
+  PortConfiguration_builder->set_vpc_id(vpc_id_2);
+  PortConfiguration_builder->set_name(port_name_4);
+  PortConfiguration_builder->set_mac_address(vmac_address_4);
+  FixedIp_builder->set_ip_address(vip_address_4);
+  FixedIp_builder->set_subnet_id(subnet_id_2);
+
+  // fill in subnet state structs
+  SubnetConiguration_builder->set_vpc_id(vpc_id_2);
+  SubnetConiguration_builder->set_id(subnet_id_2);
+  SubnetConiguration_builder->set_cidr("10.0.1.0/24");
+  SubnetConiguration_builder->set_tunnel_id(30);
+
+  // fill in port state structs for NEIGHBOR_CREATE_UPDATE for port 2
+  PortConfiguration_builder2->set_vpc_id(vpc_id_2);
+  PortConfiguration_builder2->set_mac_address(vmac_address_2);
+  FixedIp_builder2->set_subnet_id(subnet_id_2);
+  FixedIp_builder2->set_ip_address(vip_address_2);
+
+  // create a new port 4 + port 2 neighbor in demo mode
+  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
+          GoalState_builder, gsOperationalReply);
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // restore demo mode
+  g_demo_mode = previous_demo_mode;
+
+  // check to ensure the port 4 is created and setup correctly
+  ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
+          "get Interface " + port_name_4 + " ofport", not_care_culminative_time, overall_rc);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // test traffic between the two newly created ports
+  cmd_string = "ping -I " + vip_address_3 + " -c1 " + vip_address_4;
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  cmd_string = "ping -I " + vip_address_4 + " -c1 " + vip_address_3;
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // clean up
+
+  // free the allocated configurations since we are done with it now
+  new_port_states->clear_configuration();
+  new_port_neighbor_states->clear_configuration();
+  new_subnet_states->clear_configuration();
+
+  // not deleting br-int and br-tun bridges so that master can ping the two new ports
 }
 
 TEST(net_config_test_cases, create_namespace_invalid)
@@ -979,509 +1336,6 @@ TEST(net_config_test_cases, rename_veth_device_valid)
   rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
   EXPECT_EQ(rc, EXIT_SUCCESS);
 }
-
-#if 0 // disable the mizar test cases
-TEST(mizar_config_test_cases, subnet_CREATE_UPDATE_ROUTER)
-{
-  string vpc_id = "99d9d709-8478-4b46-9f3f-2206b1023fd3";
-  string gateway_ip = "10.0.0.1";
-  string gateway_mac = "fa:16:3e:d7:f2:00";
-  int rc;
-
-  GoalState GoalState_builder;
-  SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
-
-  // fill in the subnet state structs
-  new_subnet_states->set_operation_type(OperationType::CREATE_UPDATE_ROUTER);
-
-  // this will allocate new SubnetConfiguration, will need to free it later
-  SubnetConfiguration *SubnetConiguration_builder =
-          new_subnet_states->mutable_configuration();
-  SubnetConiguration_builder->set_format_version(1);
-  SubnetConiguration_builder->set_project_id("dbf72700-5106-4a7a-918f-111111111111");
-  SubnetConiguration_builder->set_vpc_id(vpc_id);
-  SubnetConiguration_builder->set_id("superSubnetID");
-  SubnetConiguration_builder->set_name("SuperSubnet");
-  SubnetConiguration_builder->set_cidr("10.0.0.0/16");
-  SubnetConiguration_builder->set_tunnel_id(22222);
-  SubnetConfiguration_Gateway *SubnetConiguration_Gateway_builder =
-          SubnetConiguration_builder->mutable_gateway();
-  SubnetConiguration_Gateway_builder->set_ip_address(gateway_ip);
-  SubnetConiguration_Gateway_builder->set_mac_address(gateway_mac);
-  // this will allocate new SubnetConfiguration_TransitSwitch, may need to free it later
-  SubnetConfiguration_TransitSwitch *TransitSwitch_builder =
-          SubnetConiguration_builder->add_transit_switches();
-  TransitSwitch_builder->set_vpc_id(vpc_id);
-  TransitSwitch_builder->set_subnet_id("superSubnet");
-  TransitSwitch_builder->set_ip_address("172.0.0.1");
-  TransitSwitch_builder->set_mac_address("cc:dd:ee:aa:bb:cc");
-
-  GoalStateOperationReply gsOperationalReply;
-
-  rc = Aca_Comm_Manager::get_instance().update_goal_state(GoalState_builder, gsOperationalReply);
-  // rc can be error if transitd is not loaded
-  if (g_transitd_loaded) {
-    ASSERT_EQ(rc, EXIT_SUCCESS);
-  }
-
-  new_subnet_states->clear_configuration();
-}
-
-TEST(mizar_config_test_cases, subnet_CREATE_UPDATE_GATEWAY)
-{
-  string vpc_id = "99d9d709-8478-4b46-9f3f-2206b1023fd3";
-  string gateway_ip = "10.0.0.1";
-  string gateway_mac = "fa:16:3e:d7:f2:00";
-  int rc;
-
-  GoalState GoalState_builder;
-  SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
-
-  // fill in the subnet state structs
-  new_subnet_states->set_operation_type(OperationType::CREATE_UPDATE_GATEWAY);
-
-  // this will allocate new SubnetConfiguration, will need to free it later
-  SubnetConfiguration *SubnetConiguration_builder =
-          new_subnet_states->mutable_configuration();
-  SubnetConiguration_builder->set_format_version(1);
-  SubnetConiguration_builder->set_project_id("dbf72700-5106-4a7a-918f-111111111111");
-  SubnetConiguration_builder->set_vpc_id(vpc_id);
-  SubnetConiguration_builder->set_id("superSubnetID");
-  SubnetConiguration_builder->set_name("SuperSubnet");
-  SubnetConiguration_builder->set_cidr("10.0.0.0/16");
-  SubnetConiguration_builder->set_tunnel_id(22222);
-  SubnetConfiguration_Gateway *SubnetConiguration_Gateway_builder =
-          SubnetConiguration_builder->mutable_gateway();
-  SubnetConiguration_Gateway_builder->set_ip_address(gateway_ip);
-  SubnetConiguration_Gateway_builder->set_mac_address(gateway_mac);
-  // this will allocate new SubnetConfiguration_TransitSwitch, may need to free it later
-  SubnetConfiguration_TransitSwitch *TransitSwitch_builder =
-          SubnetConiguration_builder->add_transit_switches();
-  TransitSwitch_builder->set_vpc_id(vpc_id);
-  TransitSwitch_builder->set_subnet_id("superSubnet");
-  TransitSwitch_builder->set_ip_address("172.0.0.1");
-  TransitSwitch_builder->set_mac_address("cc:dd:ee:aa:bb:cc");
-
-  GoalStateOperationReply gsOperationalReply;
-  rc = Aca_Comm_Manager::get_instance().update_goal_state(GoalState_builder, gsOperationalReply);
-  // rc can be error if transitd is not loaded
-  if (g_transitd_loaded) {
-    ASSERT_EQ(rc, EXIT_SUCCESS);
-  }
-
-  new_subnet_states->clear_configuration();
-}
-
-TEST(mizar_config_test_cases, subnet_CREATE_UPDATE_GATEWAY_100)
-{
-  string vpc_id = "99d9d709-8478-4b46-9f3f-2206b1023fd3";
-  string gateway_ip_postfix = ".0.0.1";
-  string gateway_mac_prefix = "fa:16:3e:d7:f2:";
-  int rc;
-
-  GoalState GoalState_builder;
-  SubnetState *new_subnet_states;
-
-  for (int i = 0; i < 100; i++) {
-    string i_string = std::to_string(i);
-
-    new_subnet_states = GoalState_builder.add_subnet_states();
-    new_subnet_states->set_operation_type(OperationType::CREATE_UPDATE_GATEWAY);
-
-    // this will allocate new SubnetConfiguration, will need to free it later
-    SubnetConfiguration *SubnetConiguration_builder =
-            new_subnet_states->mutable_configuration();
-    SubnetConiguration_builder->set_format_version(1);
-    SubnetConiguration_builder->set_project_id("dbf72700-5106-4a7a-918f-111111111111");
-    SubnetConiguration_builder->set_vpc_id(vpc_id);
-    SubnetConiguration_builder->set_id("superSubnetID" + i_string);
-    SubnetConiguration_builder->set_name("SuperSubnet");
-    SubnetConiguration_builder->set_cidr(i_string + ".0.0.0/16");
-    SubnetConiguration_builder->set_tunnel_id(22222);
-    SubnetConfiguration_Gateway *SubnetConiguration_Gateway_builder =
-            SubnetConiguration_builder->mutable_gateway();
-    SubnetConiguration_Gateway_builder->set_ip_address(i_string + gateway_ip_postfix);
-    SubnetConiguration_Gateway_builder->set_mac_address(gateway_mac_prefix + i_string);
-    // this will allocate new SubnetConfiguration_TransitSwitch, may need to free it later
-    SubnetConfiguration_TransitSwitch *TransitSwitch_builder =
-            SubnetConiguration_builder->add_transit_switches();
-    TransitSwitch_builder->set_vpc_id(vpc_id);
-    TransitSwitch_builder->set_subnet_id("superSubnet");
-    TransitSwitch_builder->set_ip_address("172.0.0.1");
-    TransitSwitch_builder->set_mac_address("cc:dd:ee:aa:bb:cc");
-  }
-
-  GoalStateOperationReply gsOperationalReply;
-  rc = Aca_Comm_Manager::get_instance().update_goal_state(GoalState_builder, gsOperationalReply);
-  // rc can be error if transitd is not loaded
-  if (g_transitd_loaded) {
-    ASSERT_EQ(rc, EXIT_SUCCESS);
-  }
-
-  new_subnet_states->clear_configuration();
-}
-
-TEST(mizar_config_test_cases, port_CREATE_UPDATE_SWITCH_100)
-{
-  string port_name = "11111111-2222-3333-4444-555555555555";
-  string vpc_id = "99d9d709-8478-4b46-9f3f-2206b1023fd3";
-  string vpc_ns = "vpc-ns-" + vpc_id;
-  string ip_address = "10.0.0.2";
-  string mac_address = "fa:16:3e:d7:f2:6c";
-  string gateway_ip = "10.0.0.1";
-  string gateway_mac = "fa:16:3e:d7:f2:00";
-  string cmd_string;
-  int rc;
-
-  string truncated_port_id = port_name.substr(0, 11);
-  string temp_name_string = "temp" + truncated_port_id;
-  string veth_name_string = "veth" + truncated_port_id;
-
-  GoalState GoalState_builder;
-  PortState *new_port_states;
-  SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
-
-  for (int i = 0; i < 100; i++) {
-    new_port_states = GoalState_builder.add_port_states();
-    new_port_states->set_operation_type(OperationType::CREATE_UPDATE_SWITCH);
-
-    // this will allocate new PortConfiguration, may need to free it later
-    PortConfiguration *PortConfiguration_builder =
-            new_port_states->mutable_configuration();
-    PortConfiguration_builder->set_format_version(1);
-    PortConfiguration_builder->set_project_id("dbf72700-5106-4a7a-918f-111111111111");
-    PortConfiguration_builder->set_id(port_name);
-    PortConfiguration_builder->set_name("FriendlyPortName");
-    PortConfiguration_builder->set_network_ns("");
-    PortConfiguration_builder->set_mac_address(mac_address);
-    PortConfiguration_builder->set_veth_name("veth0");
-
-    PortConfiguration_HostInfo *portConfig_HostInfoBuilder(new PortConfiguration_HostInfo);
-    portConfig_HostInfoBuilder->set_ip_address("172.0.0.2");
-    portConfig_HostInfoBuilder->set_mac_address("aa-bb-cc-dd-ee-ff");
-    PortConfiguration_builder->set_allocated_host_info(portConfig_HostInfoBuilder);
-
-    // this will allocate new PortConfiguration_FixedIp may need to free later
-    PortConfiguration_FixedIp *PortIp_builder =
-            PortConfiguration_builder->add_fixed_ips();
-    PortIp_builder->set_ip_address(ip_address);
-    PortIp_builder->set_subnet_id("superSubnetID");
-    // this will allocate new PortConfiguration_SecurityGroupId may need to free later
-    PortConfiguration_SecurityGroupId *SecurityGroup_builder =
-            PortConfiguration_builder->add_security_group_ids();
-    SecurityGroup_builder->set_id("1");
-    // this will allocate new PortConfiguration_AllowAddressPair may need to free later
-    PortConfiguration_AllowAddressPair *AddressPair_builder =
-            PortConfiguration_builder->add_allow_address_pairs();
-    AddressPair_builder->set_ip_address("10.0.0.5");
-    AddressPair_builder->set_mac_address("fa:16:3e:d7:f2:9f");
-  }
-
-  // fill in the subnet state structs
-  new_subnet_states->set_operation_type(OperationType::INFO);
-
-  // this will allocate new SubnetConfiguration, will need to free it later
-  SubnetConfiguration *SubnetConiguration_builder =
-          new_subnet_states->mutable_configuration();
-  SubnetConiguration_builder->set_format_version(1);
-  SubnetConiguration_builder->set_project_id("dbf72700-5106-4a7a-918f-111111111111");
-  SubnetConiguration_builder->set_vpc_id(vpc_id);
-  SubnetConiguration_builder->set_id("superSubnetID");
-  SubnetConiguration_builder->set_name("SuperSubnet");
-  SubnetConiguration_builder->set_cidr("10.0.0.0/16");
-  SubnetConiguration_builder->set_tunnel_id(22222);
-  SubnetConfiguration_Gateway *SubnetConiguration_Gateway_builder =
-          SubnetConiguration_builder->mutable_gateway();
-  SubnetConiguration_Gateway_builder->set_ip_address(gateway_ip);
-  SubnetConiguration_Gateway_builder->set_mac_address(gateway_mac);
-  // this will allocate new SubnetConfiguration_TransitSwitch, may need to free it later
-  SubnetConfiguration_TransitSwitch *TransitSwitch_builder =
-          SubnetConiguration_builder->add_transit_switches();
-  TransitSwitch_builder->set_vpc_id(vpc_id);
-  TransitSwitch_builder->set_subnet_id("superSubnet");
-  TransitSwitch_builder->set_ip_address("172.0.0.1");
-  TransitSwitch_builder->set_mac_address("cc:dd:ee:aa:bb:cc");
-
-  GoalStateOperationReply gsOperationalReply;
-  rc = Aca_Comm_Manager::get_instance().update_goal_state(GoalState_builder, gsOperationalReply);
-  // rc can be error if transitd is not loaded
-  if (g_transitd_loaded) {
-    EXPECT_EQ(rc, EXIT_SUCCESS);
-  }
-
-  // free the allocated configurations since we are done with it now
-  new_port_states->clear_configuration();
-  new_subnet_states->clear_configuration();
-}
-
-TEST(mizar_config_test_cases, port_CREATE_integrated)
-{
-  string port_name = "11111111-2222-3333-4444-555555555555";
-  string vpc_id = "99d9d709-8478-4b46-9f3f-2206b1023fd3";
-  string vpc_ns = "vpc-ns-" + vpc_id;
-  string ip_address = "10.0.0.2";
-  string mac_address = "fa:16:3e:d7:f2:6c";
-  string gateway_ip = "10.0.0.1";
-  string gateway_mac = "fa:16:3e:d7:f2:00";
-  string veth_name = "veth0";
-  string cmd_string;
-  int rc;
-
-  string truncated_port_id = port_name.substr(0, 11);
-  string temp_name_string = "temp" + truncated_port_id;
-  string peer_name_string = "peer" + truncated_port_id;
-
-  GoalState GoalState_builder;
-  PortState *new_port_states = GoalState_builder.add_port_states();
-  SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
-
-  // fill in port state structs
-  new_port_states->set_operation_type(OperationType::CREATE);
-
-  // this will allocate new PortConfiguration, will need to free it later
-  PortConfiguration *PortConfiguration_builder = new_port_states->mutable_configuration();
-  PortConfiguration_builder->set_format_version(1);
-  PortConfiguration_builder->set_project_id("dbf72700-5106-4a7a-918f-111111111111");
-  PortConfiguration_builder->set_id(port_name);
-  PortConfiguration_builder->set_name("FriendlyPortName");
-  PortConfiguration_builder->set_network_ns("");
-  PortConfiguration_builder->set_mac_address(mac_address);
-  PortConfiguration_builder->set_veth_name(veth_name);
-
-  PortConfiguration_HostInfo *portConfig_HostInfoBuilder(new PortConfiguration_HostInfo);
-  portConfig_HostInfoBuilder->set_ip_address("172.0.0.2");
-  portConfig_HostInfoBuilder->set_mac_address("aa-bb-cc-dd-ee-ff");
-  PortConfiguration_builder->set_allocated_host_info(portConfig_HostInfoBuilder);
-
-  // this will allocate new PortConfiguration_FixedIp may need to free later
-  PortConfiguration_FixedIp *PortIp_builder = PortConfiguration_builder->add_fixed_ips();
-  PortIp_builder->set_ip_address(ip_address);
-  PortIp_builder->set_subnet_id("superSubnetID");
-  // this will allocate new PortConfiguration_SecurityGroupId may need to free later
-  PortConfiguration_SecurityGroupId *SecurityGroup_builder =
-          PortConfiguration_builder->add_security_group_ids();
-  SecurityGroup_builder->set_id("1");
-  // this will allocate new PortConfiguration_AllowAddressPair may need to free later
-  PortConfiguration_AllowAddressPair *AddressPair_builder =
-          PortConfiguration_builder->add_allow_address_pairs();
-  AddressPair_builder->set_ip_address("10.0.0.5");
-  AddressPair_builder->set_mac_address("fa:16:3e:d7:f2:9f");
-
-  // fill in the subnet state structs
-  new_subnet_states->set_operation_type(OperationType::INFO);
-
-  // this will allocate new SubnetConfiguration, will need to free it later
-  SubnetConfiguration *SubnetConiguration_builder =
-          new_subnet_states->mutable_configuration();
-  SubnetConiguration_builder->set_format_version(1);
-  SubnetConiguration_builder->set_project_id("dbf72700-5106-4a7a-918f-111111111111");
-  SubnetConiguration_builder->set_vpc_id(vpc_id);
-  SubnetConiguration_builder->set_id("superSubnetID");
-  SubnetConiguration_builder->set_name("SuperSubnet");
-  SubnetConiguration_builder->set_cidr("10.0.0.0/16");
-  SubnetConiguration_builder->set_tunnel_id(22222);
-  SubnetConfiguration_Gateway *SubnetConiguration_Gateway_builder =
-          SubnetConiguration_builder->mutable_gateway();
-  SubnetConiguration_Gateway_builder->set_ip_address(gateway_ip);
-  SubnetConiguration_Gateway_builder->set_mac_address(gateway_mac);
-  // this will allocate new SubnetConfiguration_TransitSwitch, may need to free it later
-  SubnetConfiguration_TransitSwitch *TransitSwitch_builder =
-          SubnetConiguration_builder->add_transit_switches();
-  TransitSwitch_builder->set_vpc_id(vpc_id);
-  TransitSwitch_builder->set_subnet_id("superSubnet");
-  TransitSwitch_builder->set_ip_address("172.0.0.1");
-  TransitSwitch_builder->set_mac_address("cc:dd:ee:aa:bb:cc");
-
-  bool previous_demo_mode = g_demo_mode;
-  g_demo_mode = true;
-
-  GoalStateOperationReply gsOperationalReply;
-  rc = Aca_Comm_Manager::get_instance().update_goal_state(GoalState_builder, gsOperationalReply);
-  // rc can be error if transitd is not loaded
-  if (g_transitd_loaded) {
-    ASSERT_EQ(rc, EXIT_SUCCESS);
-  }
-
-  g_demo_mode = previous_demo_mode;
-
-  // check to ensure the endpoint is created and setup correctly
-
-  // the temp veth should be in the new namespace now
-  cmd_string = IP_NETNS_PREFIX + "exec " + vpc_ns + " ip link list | grep " + temp_name_string;
-  rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
-  EXPECT_EQ(rc, EXIT_SUCCESS);
-
-  // was the ip set correctly?
-  cmd_string = IP_NETNS_PREFIX + "exec " + vpc_ns + " ifconfig " +
-               temp_name_string + " | grep " + ip_address;
-  rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
-  EXPECT_EQ(rc, EXIT_SUCCESS);
-
-  // was the default gw set correctly?
-  cmd_string = IP_NETNS_PREFIX + "exec " + vpc_ns + " ip route" + " | grep " + gateway_ip;
-  rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
-  EXPECT_EQ(rc, EXIT_SUCCESS);
-
-  // was the mac set correctly?
-  cmd_string = IP_NETNS_PREFIX + "exec " + vpc_ns + " ifconfig " +
-               temp_name_string + " | grep " + mac_address;
-  rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
-  EXPECT_EQ(rc, EXIT_SUCCESS);
-
-  // finalize the endpoint, which will rename the veth to the final name
-  PortState *final_port_states = GoalState_builder.mutable_port_states(0);
-  final_port_states->set_operation_type(OperationType::FINALIZE);
-
-  rc = Aca_Comm_Manager::get_instance().update_goal_state(GoalState_builder, gsOperationalReply);
-  // rc can be error if transitd is not loaded
-  if (g_transitd_loaded) {
-    EXPECT_EQ(rc, EXIT_SUCCESS);
-  }
-
-  // free the allocated configurations since we are done with it now
-  new_port_states->clear_configuration();
-  new_subnet_states->clear_configuration();
-
-  // check to ensure the end point has been renamed to the final name
-  cmd_string = IP_NETNS_PREFIX + "exec " + vpc_ns + " ip link list | grep " + veth_name;
-  rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
-  EXPECT_EQ(rc, EXIT_SUCCESS);
-
-  // clean up
-
-  // TODO: should the test wait before cleaning things up?
-
-  ulong culminative_network_configuration_time = 0;
-
-  // delete the newly created veth pair
-  rc = Aca_Net_Config::get_instance().delete_veth_pair(
-          peer_name_string, culminative_network_configuration_time);
-  EXPECT_EQ(rc, EXIT_SUCCESS);
-
-  // delete the newly created ns
-  cmd_string = IP_NETNS_PREFIX + "delete " + vpc_ns;
-
-  rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
-  EXPECT_EQ(rc, EXIT_SUCCESS);
-}
-
-TEST(mizar_config_test_cases, port_CREATE_10)
-{
-  string network_id = "superSubnetID";
-  string port_name_postfix = "11111111-2222-3333-4444-555555555555";
-  string vpc_id = "99d9d709-8478-4b46-9f3f-2206b1023fa";
-  string vpc_ns = "vpc-ns-" + vpc_id;
-  string ip_address_prefix = "10.0.0.";
-  string mac_address_prefix = "fa:16:3e:d7:f2:6";
-  string gateway_ip = "10.0.0.1";
-  string gateway_mac = "fa:16:3e:d7:f2:00";
-  string cmd_string;
-  ulong culminative_network_configuration_time = 0;
-  int rc;
-
-  GoalState GoalState_builder;
-  PortState *new_port_states;
-  SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
-
-  const int PORTS_TO_CREATE = 10;
-
-  for (int i = 0; i < PORTS_TO_CREATE; i++) {
-    string i_string = std::to_string(i);
-    string port_name = i_string + port_name_postfix;
-
-    new_port_states = GoalState_builder.add_port_states();
-    new_port_states->set_operation_type(OperationType::CREATE);
-
-    // this will allocate new PortConfiguration, may need to free it later
-    PortConfiguration *PortConfiguration_builder =
-            new_port_states->mutable_configuration();
-    PortConfiguration_builder->set_format_version(1);
-    PortConfiguration_builder->set_project_id("dbf72700-5106-4a7a-918f-111111111111");
-    PortConfiguration_builder->set_id(port_name);
-    PortConfiguration_builder->set_name("FriendlyPortName");
-    PortConfiguration_builder->set_network_ns("");
-    PortConfiguration_builder->set_mac_address(mac_address_prefix + i_string);
-    PortConfiguration_builder->set_veth_name("veth0");
-
-    PortConfiguration_HostInfo *portConfig_HostInfoBuilder(new PortConfiguration_HostInfo);
-    portConfig_HostInfoBuilder->set_ip_address("172.0.0.2");
-    portConfig_HostInfoBuilder->set_mac_address("aa-bb-cc-dd-ee-ff");
-    PortConfiguration_builder->set_allocated_host_info(portConfig_HostInfoBuilder);
-
-    // this will allocate new PortConfiguration_FixedIp may need to free later
-    PortConfiguration_FixedIp *PortIp_builder =
-            PortConfiguration_builder->add_fixed_ips();
-    PortIp_builder->set_ip_address(ip_address_prefix + i_string);
-    PortIp_builder->set_subnet_id("superSubnetID");
-    // this will allocate new PortConfiguration_SecurityGroupId may need to free later
-    PortConfiguration_SecurityGroupId *SecurityGroup_builder =
-            PortConfiguration_builder->add_security_group_ids();
-    SecurityGroup_builder->set_id("1");
-    // this will allocate new PortConfiguration_AllowAddressPair may need to free later
-    PortConfiguration_AllowAddressPair *AddressPair_builder =
-            PortConfiguration_builder->add_allow_address_pairs();
-    AddressPair_builder->set_ip_address("10.0.0.5");
-    AddressPair_builder->set_mac_address("fa:16:3e:d7:f2:9f");
-  }
-
-  // fill in the subnet state structs
-  new_subnet_states->set_operation_type(OperationType::INFO);
-
-  // this will allocate new SubnetConfiguration, will need to free it later
-  SubnetConfiguration *SubnetConiguration_builder =
-          new_subnet_states->mutable_configuration();
-  SubnetConiguration_builder->set_format_version(1);
-  SubnetConiguration_builder->set_project_id("dbf72700-5106-4a7a-918f-111111111111");
-  SubnetConiguration_builder->set_vpc_id(vpc_id);
-  SubnetConiguration_builder->set_id(network_id);
-  SubnetConiguration_builder->set_name("SuperSubnet");
-  SubnetConiguration_builder->set_cidr("10.0.0.0/16");
-  SubnetConiguration_builder->set_tunnel_id(22222);
-  SubnetConfiguration_Gateway *SubnetConiguration_Gateway_builder =
-          SubnetConiguration_builder->mutable_gateway();
-  SubnetConiguration_Gateway_builder->set_ip_address(gateway_ip);
-  SubnetConiguration_Gateway_builder->set_mac_address(gateway_mac);
-  // this will allocate new SubnetConfiguration_TransitSwitch, may need to free it later
-  SubnetConfiguration_TransitSwitch *TransitSwitch_builder =
-          SubnetConiguration_builder->add_transit_switches();
-  TransitSwitch_builder->set_vpc_id(vpc_id);
-  TransitSwitch_builder->set_subnet_id("superSubnet");
-  TransitSwitch_builder->set_ip_address("172.0.0.1");
-  TransitSwitch_builder->set_mac_address("cc:dd:ee:aa:bb:cc");
-
-  bool previous_demo_mode = g_demo_mode;
-  g_demo_mode = false;
-
-  GoalStateOperationReply gsOperationalReply;
-  rc = Aca_Comm_Manager::get_instance().update_goal_state(GoalState_builder, gsOperationalReply);
-  // rc can be error if transitd is not loaded
-  if (g_transitd_loaded) {
-    EXPECT_EQ(rc, EXIT_SUCCESS);
-  }
-
-  g_demo_mode = previous_demo_mode;
-
-  // clean up
-  for (int i = 0; i < PORTS_TO_CREATE; i++) {
-    string i_string = std::to_string(i);
-    string port_name = i_string + port_name_postfix;
-
-    string truncated_port_id = port_name.substr(0, 11);
-    string peer_name_string = "peer" + truncated_port_id;
-
-    // delete the newly created veth pair
-    rc = Aca_Net_Config::get_instance().delete_veth_pair(
-            peer_name_string, culminative_network_configuration_time);
-    EXPECT_EQ(rc, EXIT_SUCCESS);
-  }
-
-  // delete the newly created ns
-  cmd_string = IP_NETNS_PREFIX + "delete " + vpc_ns;
-
-  rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
-  EXPECT_EQ(rc, EXIT_SUCCESS);
-}
-#endif
 
 int main(int argc, char **argv)
 {

--- a/test/gtest/aca_tests.cpp
+++ b/test/gtest/aca_tests.cpp
@@ -150,7 +150,7 @@ TEST(ovs_dataplane_test_cases, 2_ports_config_test_traffic)
   overall_rc = EXIT_SUCCESS;
 
   // create and setup br-int and br-tun bridges, and their patch ports
-  overall_rc = ACA_OVS_Programmer::get_instance().setup_bridges();
+  overall_rc = ACA_OVS_Programmer::get_instance().setup_ovs_bridges_if_need();
   ASSERT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
@@ -351,11 +351,6 @@ TEST(ovs_dataplane_test_cases, 1_port_NEIGHBOR_CREATE_UPDATE)
   ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
           "del-br br-tun", not_care_culminative_time, overall_rc);
 
-  // create and setup br-int and br-tun bridges, and their patch ports
-  overall_rc = ACA_OVS_Programmer::get_instance().setup_bridges();
-  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
-
   // NEIGHBOR_CREATE_UPDATE
   GoalStateOperationReply gsOperationalReply;
 
@@ -436,11 +431,6 @@ TEST(ovs_dataplane_test_cases, 1_port_CREATE_plus_NEIGHBOR_CREATE_UPDATE)
 
   ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
           "del-br br-tun", not_care_culminative_time, overall_rc);
-
-  // create and setup br-int and br-tun bridges, and their patch ports
-  overall_rc = ACA_OVS_Programmer::get_instance().setup_bridges();
-  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
 
   // set demo mode
   bool previous_demo_mode = g_demo_mode;
@@ -530,11 +520,6 @@ TEST(ovs_dataplane_test_cases, 2_ports_CREATE_test_traffic)
 
   ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
           "del-br br-tun", not_care_culminative_time, overall_rc);
-
-  // create and setup br-int and br-tun bridges, and their patch ports
-  overall_rc = ACA_OVS_Programmer::get_instance().setup_bridges();
-  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
 
   // set demo mode
   bool previous_demo_mode = g_demo_mode;

--- a/test/gtest/aca_tests.cpp
+++ b/test/gtest/aca_tests.cpp
@@ -29,8 +29,6 @@ using aca_comm_manager::Aca_Comm_Manager;
 
 // Defines
 #define ACALOGNAME "AlcorControlAgentTest"
-static char LOCALHOST[] = "localhost";
-static char UDP_PROTOCOL[] = "udp";
 
 static char EMPTY_STRING[] = "";
 static char VALID_STRING[] = "VALID_STRING";
@@ -53,20 +51,15 @@ static string vip_address_1 = "10.0.0.1";
 static string vip_address_2 = "10.0.1.2";
 static string vip_address_3 = "10.0.0.3";
 static string vip_address_4 = "10.0.1.4";
-static string remote_ip_1 = "172.17.0.2";
-static string remote_ip_2 = "172.17.0.3";
+static string remote_ip_1 = "10.213.43.188"; // "172.17.0.2"; for docker network
+static string remote_ip_2 = "10.213.43.187"; // "172.17.0.3"; for docker network
 static NetworkType vxlan_type = NetworkType::VXLAN;
 
 // Global variables
-string g_rpc_server = EMPTY_STRING;
-string g_rpc_protocol = EMPTY_STRING;
-std::atomic_ulong g_total_rpc_call_time(0);
-std::atomic_ulong g_total_rpc_client_time(0);
 std::atomic_ulong g_total_network_configuration_time(0);
 std::atomic_ulong g_total_update_GS_time(0);
 bool g_debug_mode = true;
 bool g_demo_mode = false;
-bool g_transitd_loaded = false;
 
 using aca_net_config::Aca_Net_Config;
 using aca_ovs_programmer::ACA_OVS_Programmer;
@@ -87,12 +80,6 @@ using aca_ovs_programmer::ACA_OVS_Programmer;
 
 static void aca_cleanup()
 {
-  ACA_LOG_DEBUG("g_total_rpc_call_time = %lu nanoseconds or %lu milliseconds\n",
-                g_total_rpc_call_time.load(), g_total_rpc_call_time.load() / 1000000);
-
-  ACA_LOG_DEBUG("g_total_rpc_client_time = %lu nanoseconds or %lu milliseconds\n",
-                g_total_rpc_client_time.load(), g_total_rpc_client_time.load() / 1000000);
-
   ACA_LOG_DEBUG("g_total_network_configuration_time = %lu nanoseconds or %lu milliseconds\n",
                 g_total_network_configuration_time.load(),
                 g_total_network_configuration_time.load() / 1000000);
@@ -1349,35 +1336,22 @@ int main(int argc, char **argv)
 
   testing::InitGoogleTest(&argc, argv);
 
-  while ((option = getopt(argc, argv, "s:p:t")) != -1) {
+  while ((option = getopt(argc, argv, "m:s:")) != -1) {
     switch (option) {
+    case 'm':
+      remote_ip_1 = optarg;
+      break;
     case 's':
-      g_rpc_server = optarg;
-      break;
-    case 'p':
-      g_rpc_protocol = optarg;
-      break;
-    case 't':
-      g_transitd_loaded = true;
+      remote_ip_2 = optarg;
       break;
     default: /* the '?' case when the option is not recognized */
       fprintf(stderr,
               "Usage: %s\n"
-              "\t\t[-s transitd RPC server]\n"
-              "\t\t[-p transitd RPC protocol]\n"
-              "\t\t[-t transitd is loaded]\n",
+              "\t\t[-m master machine IP]\n"
+              "\t\t[-s slave machine IP]\n",
               argv[0]);
       exit(EXIT_FAILURE);
     }
-  }
-
-  // fill in the transitd RPC server and protocol if it is not provided in
-  // command line arg
-  if (g_rpc_server == EMPTY_STRING) {
-    g_rpc_server = LOCALHOST;
-  }
-  if (g_rpc_protocol == EMPTY_STRING) {
-    g_rpc_protocol = UDP_PROTOCOL;
   }
 
   int rc = RUN_ALL_TESTS();


### PR DESCRIPTION
This PR added Vlan manager implementation and test cases to enforce the VPC security boundary on the host and further provide tenant isolation between different VPCs. 

The change includes:

- new vlan manager class
- changes in ACA_OVS_Programmer to use the vlan manager class
- new two machine (manual) test case to test tenet isolation in different VPC