### PR TITLE
Hotfix to enable openstack nova integration

### DIFF
--- a/build/aca-machine-init.sh
+++ b/build/aca-machine-init.sh
@@ -119,5 +119,5 @@ ovs-vsctl set interface patch-int options:peer=patch-tun
 ovs-ofctl add-flow br-tun "table=0, priority=1,in_port="patch-int" actions=resubmit(,2)"
 ovs-ofctl add-flow br-tun "table=2, priority=0 actions=resubmit(,22)"
 
-echo "7--- running alcor-control-agent"
+echo "9--- running alcor-control-agent"
 ./build/bin/AlcorControlAgent -d &

--- a/include/aca_config.h
+++ b/include/aca_config.h
@@ -1,0 +1,21 @@
+// Copyright 2019 The Alcor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ACA_CONFIG_H
+#define ACA_CONFIG_H
+
+#define MAX_PORT_SCAN_RETRY 300
+#define PORT_SCAN_SLEEP_INTERVAL 1000 // 1000ms = 1s
+
+#endif // #ifndef ACA_CONFIG_H

--- a/include/aca_ovs_programmer.h
+++ b/include/aca_ovs_programmer.h
@@ -27,6 +27,8 @@ class ACA_OVS_Programmer {
 
   int setup_ovs_bridges_if_need();
 
+  int set_port_vlan_workitem(const std::string port_name, uint vlan_id, ulong &culminative_time);
+
   int configure_port(const std::string vpc_id, const std::string port_name,
                      const std::string virtual_ip, uint tunnel_id, ulong &culminative_time);
 

--- a/include/aca_ovs_programmer.h
+++ b/include/aca_ovs_programmer.h
@@ -27,8 +27,6 @@ class ACA_OVS_Programmer {
 
   int setup_ovs_bridges_if_need();
 
-  int set_port_vlan_workitem(const std::string port_name, uint vlan_id, ulong &culminative_time);
-
   int configure_port(const std::string vpc_id, const std::string port_name,
                      const std::string virtual_ip, uint tunnel_id, ulong &culminative_time);
 

--- a/include/aca_util.h
+++ b/include/aca_util.h
@@ -23,6 +23,9 @@
 // it should be more than enough for the number of hosts in a region
 #define MAX_OUTPORT_NAME_POSTFIX 99999999
 
+#define TAP_PREFIX "tap" // vm tap device prefix
+#define PORT_NAME_LEN 14 // Nova generated port name length
+
 #define cast_to_nanoseconds(x) chrono::duration_cast<chrono::nanoseconds>(x)
 
 static inline std::string aca_get_network_type_string(alcor::schema::NetworkType network_type)
@@ -57,9 +60,6 @@ aca_get_outport_name(alcor::schema::NetworkType network_type, std::string remote
 
 static inline std::string aca_get_port_name(std::string port_id)
 {
-  static char TAP_PREFIX[] = "tap";
-  static ushort PORT_NAME_LEN = 14;
-
   std::string port_name = TAP_PREFIX + port_id;
   port_name = port_name.substr(0, PORT_NAME_LEN);
 

--- a/include/aca_util.h
+++ b/include/aca_util.h
@@ -55,6 +55,17 @@ aca_get_outport_name(alcor::schema::NetworkType network_type, std::string remote
   return aca_get_network_type_string(network_type) + "-" + std::to_string(hash_value);
 }
 
+static inline std::string aca_get_port_name(std::string port_id)
+{
+  static char TAP_PREFIX[] = "tap";
+  static ushort PORT_NAME_LEN = 14;
+
+  std::string port_name = TAP_PREFIX + port_id;
+  port_name = port_name.substr(0, PORT_NAME_LEN);
+
+  return port_name;
+}
+
 static inline const char *aca_get_operation_string(alcor::schema::OperationType operation)
 {
   switch (operation) {

--- a/src/dp_abstraction/aca_dataplane_ovs.cpp
+++ b/src/dp_abstraction/aca_dataplane_ovs.cpp
@@ -121,7 +121,7 @@ int ACA_Dataplane_OVS::update_port_state_workitem(const PortState current_PortSt
                                                   GoalStateOperationReply &gsOperationReply)
 {
   int overall_rc;
-  string port_name;
+  string generated_port_name;
   struct sockaddr_in sa;
   string found_cidr;
   uint found_tunnel_id;
@@ -155,7 +155,7 @@ int ACA_Dataplane_OVS::update_port_state_workitem(const PortState current_PortSt
 
     assert(!current_PortConfiguration.id().empty());
 
-    port_name = aca_get_port_name(current_PortConfiguration.id());
+    generated_port_name = aca_get_port_name(current_PortConfiguration.id());
 
     try {
       // TODO: add support for more than one fixed_ips in the future
@@ -216,17 +216,17 @@ int ACA_Dataplane_OVS::update_port_state_workitem(const PortState current_PortSt
 
       if (overall_rc == EXIT_SUCCESS) {
         ACA_LOG_DEBUG("Port Operation: %s: port_id: %s, project_id:%s, vpc_id:%s, network_type:%d, "
-                      "virtual_ip_address:%s, virtual_mac_address:%s, port_name: %s, port_cidr: %s, tunnel_id: %d\n",
+                      "virtual_ip_address:%s, virtual_mac_address:%s, generated_port_name: %s, port_cidr: %s, tunnel_id: %d\n",
                       aca_get_operation_string(current_PortState.operation_type()),
                       current_PortConfiguration.id().c_str(),
                       current_PortConfiguration.project_id().c_str(),
                       current_PortConfiguration.vpc_id().c_str(),
                       current_PortConfiguration.network_type(),
                       virtual_ip_address.c_str(), virtual_mac_address.c_str(),
-                      port_name.c_str(), port_cidr.c_str(), found_tunnel_id);
+                      generated_port_name.c_str(), port_cidr.c_str(), found_tunnel_id);
 
         overall_rc = ACA_OVS_Programmer::get_instance().configure_port(
-                current_PortConfiguration.vpc_id(), port_name, port_cidr,
+                current_PortConfiguration.vpc_id(), generated_port_name, port_cidr,
                 found_tunnel_id, culminative_dataplane_programming_time);
       }
 

--- a/src/dp_abstraction/aca_dataplane_ovs.cpp
+++ b/src/dp_abstraction/aca_dataplane_ovs.cpp
@@ -121,6 +121,7 @@ int ACA_Dataplane_OVS::update_port_state_workitem(const PortState current_PortSt
                                                   GoalStateOperationReply &gsOperationReply)
 {
   int overall_rc;
+  string port_name;
   struct sockaddr_in sa;
   string found_cidr;
   uint found_tunnel_id;
@@ -151,6 +152,10 @@ int ACA_Dataplane_OVS::update_port_state_workitem(const PortState current_PortSt
   case OperationType::CREATE:
 
     assert(current_PortConfiguration.message_type() == MessageType::FULL);
+
+    assert(!current_PortConfiguration.id().empty());
+
+    port_name = aca_get_port_name(current_PortConfiguration.id());
 
     try {
       // TODO: add support for more than one fixed_ips in the future
@@ -210,19 +215,19 @@ int ACA_Dataplane_OVS::update_port_state_workitem(const PortState current_PortSt
       port_cidr = virtual_ip_address + "/" + found_prefix_len;
 
       if (overall_rc == EXIT_SUCCESS) {
-        ACA_LOG_DEBUG("Port Operation: %s: project_id:%s, vpc_id:%s, network_type:%d, virtual_ip_address:%s, "
-                      "virtual_mac_address:%s, port_name: %s, port_cidr: %s, tunnel_id: %d\n",
+        ACA_LOG_DEBUG("Port Operation: %s: port_id: %s, project_id:%s, vpc_id:%s, network_type:%d, "
+                      "virtual_ip_address:%s, virtual_mac_address:%s, port_name: %s, port_cidr: %s, tunnel_id: %d\n",
                       aca_get_operation_string(current_PortState.operation_type()),
+                      current_PortConfiguration.id().c_str(),
                       current_PortConfiguration.project_id().c_str(),
                       current_PortConfiguration.vpc_id().c_str(),
                       current_PortConfiguration.network_type(),
-                      current_PortConfiguration.name().c_str(),
                       virtual_ip_address.c_str(), virtual_mac_address.c_str(),
-                      port_cidr.c_str(), found_tunnel_id);
+                      port_name.c_str(), port_cidr.c_str(), found_tunnel_id);
 
         overall_rc = ACA_OVS_Programmer::get_instance().configure_port(
-                current_PortConfiguration.vpc_id(), current_PortConfiguration.name(),
-                port_cidr, found_tunnel_id, culminative_dataplane_programming_time);
+                current_PortConfiguration.vpc_id(), port_name, port_cidr,
+                found_tunnel_id, culminative_dataplane_programming_time);
       }
 
     } catch (const std::invalid_argument &e) {

--- a/src/dp_abstraction/aca_goal_state_handler.cpp
+++ b/src/dp_abstraction/aca_goal_state_handler.cpp
@@ -190,14 +190,13 @@ void Aca_Goal_State_Handler::add_goal_state_operation_status(
 
   if (operation_rc == EXIT_SUCCESS)
     overall_operation_status = OperationStatus::SUCCESS;
+  else if (operation_rc == EINPROGRESS && resource_type == PORT &&
+           operation_type == OperationType::CREATE)
+    overall_operation_status = OperationStatus::PENDING;
   else if (operation_rc == -EINVAL)
     overall_operation_status = OperationStatus::INVALID_ARG;
   else
     overall_operation_status = OperationStatus::FAILURE;
-
-  // override overall_operation_status to
-  if (resource_type == PORT && operation_type == OperationType::CREATE)
-    overall_operation_status = OperationStatus::PENDING;
 
   ACA_LOG_DEBUG("gsOperationReply - resource_id: %s\n", id.c_str());
   ACA_LOG_DEBUG("gsOperationReply - resource_type: %d\n", resource_type);

--- a/src/dp_abstraction/aca_goal_state_handler.cpp
+++ b/src/dp_abstraction/aca_goal_state_handler.cpp
@@ -195,6 +195,10 @@ void Aca_Goal_State_Handler::add_goal_state_operation_status(
   else
     overall_operation_status = OperationStatus::FAILURE;
 
+  // override overall_operation_status to
+  if (resource_type == PORT && operation_type == OperationType::CREATE)
+    overall_operation_status = OperationStatus::PENDING;
+
   ACA_LOG_DEBUG("gsOperationReply - resource_id: %s\n", id.c_str());
   ACA_LOG_DEBUG("gsOperationReply - resource_type: %d\n", resource_type);
   ACA_LOG_DEBUG("gsOperationReply - operation_type: %d\n", operation_type);

--- a/src/ovs/aca_ovs_programmer.cpp
+++ b/src/ovs/aca_ovs_programmer.cpp
@@ -38,7 +38,7 @@ static int aca_set_port_vlan_workitem(const string port_name, uint vlan_id)
   ACA_LOG_DEBUG("aca_set_port_vlan_workitem ---> Entering\n");
 
   ulong not_care_culminative_time = 0;
-  int overall_rc = EXIT_SUCCESS;
+  int overall_rc;
 
   if (port_name.empty()) {
     throw std::invalid_argument("port_name is empty");
@@ -53,13 +53,14 @@ static int aca_set_port_vlan_workitem(const string port_name, uint vlan_id)
   string cmd_string = "set port " + port_name + " tag=" + to_string(vlan_id);
 
   do {
+    std::this_thread::sleep_for(chrono::milliseconds(1000));
+
+    overall_rc = EXIT_SUCCESS;
     ACA_OVS_Programmer::get_instance().execute_ovsdb_command(
             cmd_string, not_care_culminative_time, overall_rc);
 
     if (overall_rc == EXIT_SUCCESS)
       break;
-
-    std::this_thread::sleep_for(chrono::milliseconds(1000));
   } while (++waited_seconds < MAX_PORT_WAIT_SECONDS);
 
   if (overall_rc != EXIT_SUCCESS) {

--- a/src/ovs/aca_ovs_programmer.cpp
+++ b/src/ovs/aca_ovs_programmer.cpp
@@ -179,24 +179,26 @@ int ACA_OVS_Programmer::configure_port(const string vpc_id, const string port_na
     // so keep trying until PORT_WAIT_TIME
     string cmd_string = "set port " + port_name + " tag=" + to_string(internal_vlan_id);
 
-    static ushort MAX_PORT_WAIT_SECONDS = 300; // 5 mins
-    uint waited_seconds = 0;
+    execute_ovsdb_command(cmd_string, culminative_time, overall_rc);
 
-    do {
-      temp_rc = EXIT_SUCCESS;
-      execute_ovsdb_command(cmd_string, culminative_time, temp_rc);
+    // static ushort MAX_PORT_WAIT_SECONDS = 300; // 5 mins
+    // uint waited_seconds = 0;
 
-      if (temp_rc == EXIT_SUCCESS)
-        break;
+    // do {
+    //   temp_rc = EXIT_SUCCESS;
+    //   execute_ovsdb_command(cmd_string, culminative_time, temp_rc);
 
-      std::this_thread::sleep_for(chrono::milliseconds(1000));
-    } while (++waited_seconds < MAX_PORT_WAIT_SECONDS);
+    //   if (temp_rc == EXIT_SUCCESS)
+    //     break;
 
-    if (temp_rc != EXIT_SUCCESS) {
-      ACA_LOG_ERROR("Not able to set the vlan tag %d for port %s even after waiting\n",
-                    internal_vlan_id, port_name.c_str());
-      overall_rc = temp_rc;
-    }
+    //   std::this_thread::sleep_for(chrono::milliseconds(1000));
+    // } while (++waited_seconds < MAX_PORT_WAIT_SECONDS);
+
+    // if (temp_rc != EXIT_SUCCESS) {
+    //   ACA_LOG_ERROR("Not able to set the vlan tag %d for port %s even after waiting\n",
+    //                 internal_vlan_id, port_name.c_str());
+    //   overall_rc = temp_rc;
+    // }
   }
 
   execute_openflow_command(

--- a/src/ovs/aca_ovs_programmer.cpp
+++ b/src/ovs/aca_ovs_programmer.cpp
@@ -169,6 +169,13 @@ int ACA_OVS_Programmer::configure_port(const string vpc_id, const string port_na
             cmd_string, culminative_time);
     if (command_rc != EXIT_SUCCESS)
       overall_rc = command_rc;
+  } else {
+    // non-demo mode is for nova integration, where the vif and ovs port has been
+    // created by nova compute agent running on the compute host
+    // just need to set the vlan tag on the ovs port
+    string cmd_string = "set port " + port_name + " tag=" + to_string(internal_vlan_id);
+
+    execute_ovsdb_command(cmd_string, culminative_time, overall_rc);
   }
 
   execute_openflow_command(

--- a/test/gtest/aca_tests.cpp
+++ b/test/gtest/aca_tests.cpp
@@ -39,10 +39,14 @@ static string vpc_id_1 = "1b08a5bc-b718-11ea-b3de-111111111111";
 static string vpc_id_2 = "1b08a5bc-b718-11ea-b3de-222222222222";
 static string subnet_id_1 = "27330ae4-b718-11ea-b3de-111111111111";
 static string subnet_id_2 = "27330ae4-b718-11ea-b3de-222222222222";
-static string port_name_1 = "tap-11111111";
-static string port_name_2 = "tap-22222222";
-static string port_name_3 = "tap-33333333";
-static string port_name_4 = "tap-44444444";
+static string port_id_1 = "01111111-b718-11ea-b3de-111111111111";
+static string port_id_2 = "02222222-b718-11ea-b3de-111111111111";
+static string port_id_3 = "03333333-b718-11ea-b3de-111111111111";
+static string port_id_4 = "04444444-b718-11ea-b3de-111111111111";
+static string port_name_1 = aca_get_port_name(port_id_1);
+static string port_name_2 = aca_get_port_name(port_id_2);
+static string port_name_3 = aca_get_port_name(port_id_3);
+static string port_name_4 = aca_get_port_name(port_id_4);
 static string vmac_address_1 = "fa:16:3e:d7:f2:6c";
 static string vmac_address_2 = "fa:16:3e:d7:f2:6d";
 static string vmac_address_3 = "fa:16:3e:d7:f2:6e";
@@ -104,6 +108,7 @@ static void aca_test_create_default_port_state(PortState *new_port_states)
   PortConfiguration_builder->set_revision_number(1);
   PortConfiguration_builder->set_message_type(MessageType::FULL);
   // PortConfiguration_builder->set_network_type(NetworkType::VXLAN); // should default to VXLAN
+  PortConfiguration_builder->set_id(port_id_1);
 
   PortConfiguration_builder->set_project_id(project_id);
   PortConfiguration_builder->set_vpc_id(vpc_id_1);
@@ -503,6 +508,7 @@ TEST(ovs_dataplane_test_cases, 2_ports_CREATE_test_traffic)
   PortConfiguration_builder->set_revision_number(1);
   PortConfiguration_builder->set_message_type(MessageType::FULL);
   // PortConfiguration_builder->set_network_type(NetworkType::VXLAN); // should default to VXLAN
+  PortConfiguration_builder->set_id(port_id_1);
 
   PortConfiguration_builder->set_project_id(project_id);
   PortConfiguration_builder->set_vpc_id(vpc_id_1);
@@ -546,6 +552,7 @@ TEST(ovs_dataplane_test_cases, 2_ports_CREATE_test_traffic)
   overall_rc = EXIT_SUCCESS;
 
   // setup the configuration for port 2
+  PortConfiguration_builder->set_id(port_id_2);
   PortConfiguration_builder->set_name(port_name_2);
   PortConfiguration_builder->set_mac_address(vmac_address_2);
   FixedIp_builder->set_ip_address(vip_address_2);
@@ -609,6 +616,7 @@ TEST(ovs_dataplane_test_cases, DISABLED_2_ports_CREATE_test_traffic_MASTER)
   PortConfiguration_builder->set_revision_number(1);
   PortConfiguration_builder->set_message_type(MessageType::FULL);
   // PortConfiguration_builder->set_network_type(NetworkType::VXLAN); // should default to VXLAN
+  PortConfiguration_builder->set_id(port_id_1);
 
   PortConfiguration_builder->set_project_id(project_id);
   PortConfiguration_builder->set_vpc_id(vpc_id_1);
@@ -690,6 +698,7 @@ TEST(ovs_dataplane_test_cases, DISABLED_2_ports_CREATE_test_traffic_MASTER)
   overall_rc = EXIT_SUCCESS;
 
   // setup the configuration for port 2
+  PortConfiguration_builder->set_id(port_id_2);
   PortConfiguration_builder->set_vpc_id(vpc_id_2);
   PortConfiguration_builder->set_name(port_name_2);
   PortConfiguration_builder->set_mac_address(vmac_address_2);
@@ -793,6 +802,7 @@ TEST(ovs_dataplane_test_cases, DISABLED_2_ports_CREATE_test_traffic_SLAVE)
   PortConfiguration_builder->set_revision_number(1);
   PortConfiguration_builder->set_message_type(MessageType::FULL);
   // PortConfiguration_builder->set_network_type(NetworkType::VXLAN); // should default to VXLAN
+  PortConfiguration_builder->set_id(port_id_3);
 
   PortConfiguration_builder->set_project_id(project_id);
   PortConfiguration_builder->set_vpc_id(vpc_id_1);
@@ -874,6 +884,7 @@ TEST(ovs_dataplane_test_cases, DISABLED_2_ports_CREATE_test_traffic_SLAVE)
   overall_rc = EXIT_SUCCESS;
 
   // setup the configuration for port 4
+  PortConfiguration_builder->set_id(port_id_4);
   PortConfiguration_builder->set_vpc_id(vpc_id_2);
   PortConfiguration_builder->set_name(port_name_4);
   PortConfiguration_builder->set_mac_address(vmac_address_4);


### PR DESCRIPTION
this is the Hotfix to enable openstack nova integration, it addressed two major issues:

1. the port_name receive from nova call is empty, aca will use the port_id to generate the port_name based on the same algorithm nova compute agent uses

2. for the compute host port update call, nova compute agent is waiting for Alcor to return before creating the ovs port to plug in the new tap interface, the short term fix is for aca to return a pending call back to Alcor, and then set the vlan id on the ovs port in the background thread

We also updated the aca deployment script to make our deployment easier.