### PR TITLE
[Enhancements] remove error logging for pending status return and update documentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ In this README:
 - [Introduction](#introduction)
 - [Repositories](#repositories)
 - [Directory Structure](#directory-structure)
+- [Notes](#notes)
 
 ## Introduction
 
@@ -42,3 +43,7 @@ This main repository of Alcor Control Agent is organized as follows:
 * include: header files
 * src: source code
 * test: Unit and integration test code
+
+## Notes
+* ovs_control.h and ovs_control.cpp is based on https://github.com/openvswitch/ovs/blob/master/utilities/ovs-ofctl.c
+* aca_async_grpc_server.cpp is based on https://github.com/grpc/grpc/blob/v1.30.0/examples/cpp/helloworld/greeter_async_server.cc

--- a/docs/major_components.adoc
+++ b/docs/major_components.adoc
@@ -45,7 +45,24 @@ Responsible to manage Networking QoS, to be done in software or hardware. Out of
 
 === Work Item Executor
 
-Work item executor is used to execute the configuration updates for different dataplane implementation. It runs the workitems in parallel by default. There is a huge performance improvement when updating thousands of ports in parallel instead of updating serially based on data.
+Work item executor is used to execute the configuration updates for different dataplane implementation. It runs the workitems in parallel by default. There is a huge performance improvement when updating 10s or 100s of ports in parallel instead of updating serially based on data. 
+
+Below is an example of how parallel port provision (create) operation would look like:
+[source,console]
+------------------------------------------------------------
+[METRICS] Elapsed time for message total operation took: 23478448 nanoseconds or 23 milliseconds
+Port State(0) took: 9416690 nanoseconds or 9 milliseconds
+Port State(1) took: 10072921 nanoseconds or 10 milliseconds
+Port State(2) took: 10360112 nanoseconds or 10 milliseconds
+Port State(3) took: 10428148 nanoseconds or 10 milliseconds
+Port State(4) took: 11855690 nanoseconds or 11 milliseconds
+Port State(5) took: 11567930 nanoseconds or 11 milliseconds
+Port State(6) took: 12690876 nanoseconds or 12 milliseconds
+Port State(7) took: 11301110 nanoseconds or 11 milliseconds
+Port State(8) took: 11171870 nanoseconds or 11 milliseconds
+Port State(9) took: 12853241 nanoseconds or 12 milliseconds
+Average Port Create of 10 took: 11171858 nanoseconds or 11 milliseconds
+------------------------------------------------------------
 
 == Unified Flow Manager
 

--- a/src/comm/aca_async_grpc_server.cpp
+++ b/src/comm/aca_async_grpc_server.cpp
@@ -82,12 +82,15 @@ void Aca_Async_GRPC_Server::CallData::Proceed()
   } else if (status_ == PROCESS) {
     new CallData(service_, cq_);
     int rc = Aca_Comm_Manager::get_instance().update_goal_state(request_, reply_);
-    if (rc != EXIT_SUCCESS) {
-      ACA_LOG_ERROR("Control Fast Path - Failed to update host with latest goal state, rc=%d.\n",
-                    rc);
-    } else {
+    if (rc == EXIT_SUCCESS) {
       ACA_LOG_INFO("Control Fast Path - Successfully updated host with latest goal state %d.\n",
                    rc);
+    } else if (rc == EINPROGRESS) {
+      ACA_LOG_INFO("Control Fast Path - Update host with latest goal state returned pending, rc=%d.\n",
+                   rc);
+    } else {
+      ACA_LOG_ERROR("Control Fast Path - Failed to update host with latest goal state, rc=%d.\n",
+                    rc);
     }
     status_ = FINISH;
     responder_.Finish(reply_, Status::OK, this);

--- a/src/comm/aca_async_grpc_server.cpp
+++ b/src/comm/aca_async_grpc_server.cpp
@@ -1,16 +1,21 @@
-// Copyright 2019 The Alcor Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ * Copyright 2019 The Alcor Authors - file modified.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 #include <memory>
 #include <iostream>

--- a/src/dp_abstraction/aca_dataplane_ovs.cpp
+++ b/src/dp_abstraction/aca_dataplane_ovs.cpp
@@ -504,7 +504,7 @@ int ACA_Dataplane_OVS::update_neighbor_state_workitem(NeighborState current_Neig
         throw; // rethrowing
       }
       break;
-    } else { // (current_NeighborConfiguration.neighbor_type()==NeighborType::HOST_DVR)
+    } else {
       ACA_LOG_ERROR("Unknown neighbor_type: %d.\n", current_NeighborState.operation_type());
       overall_rc = -EINVAL;
     }

--- a/src/net_config/aca_net_config.cpp
+++ b/src/net_config/aca_net_config.cpp
@@ -332,12 +332,12 @@ int Aca_Net_Config::execute_system_command(string cmd_string, ulong &culminative
   g_total_network_configuration_time += network_configuration_elapse_time;
 
   if (rc == EXIT_SUCCESS) {
-    ACA_LOG_INFO("Command succeeded!");
+    ACA_LOG_INFO("Command succeeded!\n");
   } else {
-    ACA_LOG_DEBUG("Command failed!!! rc: %d", rc);
+    ACA_LOG_DEBUG("Command failed!!! rc: %d\n", rc);
   }
 
-  ACA_LOG_DEBUG(" Elapsed time for system command took: %ld nanoseconds or %ld milliseconds.\n\n",
+  ACA_LOG_DEBUG(" Elapsed time for system command took: %ld nanoseconds or %ld milliseconds.\n",
                 network_configuration_elapse_time,
                 network_configuration_elapse_time / 1000000);
 

--- a/src/ovs/aca_ovs_l2_programmer.cpp
+++ b/src/ovs/aca_ovs_l2_programmer.cpp
@@ -189,8 +189,6 @@ int ACA_OVS_L2_Programmer::configure_port(const string vpc_id, const string port
     throw std::invalid_argument("tunnel_id is 0");
   }
 
-  overall_rc = setup_ovs_bridges_if_need();
-
   if (overall_rc != EXIT_SUCCESS) {
     throw std::runtime_error("Invalid environment with br-int and br-tun");
   }
@@ -281,8 +279,6 @@ int ACA_OVS_L2_Programmer::create_update_neighbor_port(const string vpc_id,
     throw std::invalid_argument("tunnel_id is 0");
   }
 
-  overall_rc = setup_ovs_bridges_if_need();
-
   if (overall_rc != EXIT_SUCCESS) {
     throw std::runtime_error("Invalid environment with br-int and br-tun");
   }
@@ -307,12 +303,12 @@ int ACA_OVS_L2_Programmer::create_update_neighbor_port(const string vpc_id,
   overall_rc = ACA_Vlan_Manager::get_instance().get_outports(vpc_id, full_outport_list);
 
   if (overall_rc != EXIT_SUCCESS) {
-    throw std::runtime_error("vpc_id entry not find in vpc_table");
+    throw std::runtime_error("vpc_id entry not found in vpc_table");
   }
 
   cmd_string = "add-flow br-tun \"table=22,priority=1,dl_vlan=" + to_string(internal_vlan_id) +
                " actions=strip_vlan,load:" + to_string(tunnel_id) +
-               "->NXM_NX_TUN_ID[],output:\"" + full_outport_list + "\"\"";
+               "->NXM_NX_TUN_ID[]," + full_outport_list + "\"";
 
   execute_openflow_command(cmd_string, culminative_time, overall_rc);
 

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -73,8 +73,6 @@ int ACA_OVS_L3_Programmer::create_router(const string host_dvr_mac, const string
     throw std::invalid_argument("router_id is empty");
   }
 
-  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
-
   if (overall_rc != EXIT_SUCCESS) {
     throw std::runtime_error("Invalid environment with br-int and br-tun");
   }
@@ -168,8 +166,6 @@ int ACA_OVS_L3_Programmer::create_neighbor_l3(
   if (tunnel_id == 0) {
     throw std::invalid_argument("tunnel_id is 0");
   }
-
-  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
 
   if (overall_rc != EXIT_SUCCESS) {
     throw std::runtime_error("Invalid environment with br-int and br-tun");

--- a/src/ovs/aca_vlan_manager.cpp
+++ b/src/ovs/aca_vlan_manager.cpp
@@ -160,6 +160,7 @@ int ACA_Vlan_Manager::get_outports(string vpc_id, string &outports)
   ACA_LOG_DEBUG("ACA_Vlan_Manager::get_outports ---> Entering\n");
 
   int overall_rc;
+  static string OUTPUT = "output:\"";
 
   // -----critical section starts-----
   _vpcs_table_mutex.lock();
@@ -172,9 +173,9 @@ int ACA_Vlan_Manager::get_outports(string vpc_id, string &outports)
 
     for (auto it = current_outports.begin(); it != current_outports.end(); it++) {
       if (it == current_outports.begin()) {
-        outports += *it;
+        outports = OUTPUT + *it + "\"";
       } else {
-        outports += ' ' + *it;
+        outports += ',' + OUTPUT + *it + "\"";
       }
     }
     overall_rc = EXIT_SUCCESS;

--- a/test/gtest/aca_tests.cpp
+++ b/test/gtest/aca_tests.cpp
@@ -718,7 +718,7 @@ TEST(ovs_dataplane_test_cases, 10_l2_neighbor_CREATE)
 {
   string port_name_postfix = "11111111-2222-3333-4444-555555555555";
   string ip_address_prefix = "10.0.0.";
-  string remote_ip_address_prefix = "172.0.0.";
+  string remote_ip_address_prefix = "123.0.0.";
   ulong not_care_culminative_time = 0;
   int overall_rc;
 
@@ -737,6 +737,22 @@ TEST(ovs_dataplane_test_cases, 10_l2_neighbor_CREATE)
   GoalState GoalState_builder;
   NeighborState *new_neighbor_states;
   SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
+  new_subnet_states->set_operation_type(OperationType::INFO);
+
+  SubnetConfiguration *SubnetConiguration_builder =
+          new_subnet_states->mutable_configuration();
+  SubnetConiguration_builder->set_format_version(1);
+  SubnetConiguration_builder->set_revision_number(1);
+  SubnetConiguration_builder->set_project_id(project_id);
+  SubnetConiguration_builder->set_vpc_id("1b08a5bc-b718-11ea-b3de-111122223333");
+  SubnetConiguration_builder->set_id(subnet_id_1);
+  SubnetConiguration_builder->set_cidr("10.0.0.0/24");
+  SubnetConiguration_builder->set_tunnel_id(123);
+
+  auto *subnetConfig_GatewayBuilder(new SubnetConfiguration_Gateway);
+  subnetConfig_GatewayBuilder->set_ip_address(subnet1_gw_ip);
+  subnetConfig_GatewayBuilder->set_mac_address(subnet1_gw_mac);
+  SubnetConiguration_builder->set_allocated_gateway(subnetConfig_GatewayBuilder);
 
   const int L2_NEIGHBOR_TO_CREATE = 10;
 
@@ -754,7 +770,7 @@ TEST(ovs_dataplane_test_cases, 10_l2_neighbor_CREATE)
     NeighborConfiguration_builder->set_neighbor_type(NeighborType::L2);
 
     NeighborConfiguration_builder->set_project_id(project_id);
-    NeighborConfiguration_builder->set_vpc_id(vpc_id_1);
+    NeighborConfiguration_builder->set_vpc_id("1b08a5bc-b718-11ea-b3de-111122223333");
     NeighborConfiguration_builder->set_name(port_name);
     NeighborConfiguration_builder->set_mac_address(vmac_address_1);
     NeighborConfiguration_builder->set_host_ip_address(remote_ip_address_prefix + i_string);
@@ -764,9 +780,6 @@ TEST(ovs_dataplane_test_cases, 10_l2_neighbor_CREATE)
     FixedIp_builder->set_subnet_id(subnet_id_1);
     FixedIp_builder->set_ip_address(ip_address_prefix + i_string);
   }
-
-  // fill in the subnet state structs
-  aca_test_create_default_subnet_state(new_subnet_states);
 
   bool previous_demo_mode = g_demo_mode;
   g_demo_mode = false;

--- a/test/gtest/aca_tests.cpp
+++ b/test/gtest/aca_tests.cpp
@@ -335,6 +335,18 @@ TEST(ovs_dataplane_test_cases, 1_port_NEIGHBOR_CREATE_UPDATE)
   string cmd_string;
   int overall_rc;
 
+  // delete br-int and br-tun bridges
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-int", not_care_culminative_time, overall_rc);
+
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-tun", not_care_culminative_time, overall_rc);
+
+  // create and setup br-int and br-tun bridges, and their patch ports
+  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
   GoalState GoalState_builder;
   PortState *new_port_states = GoalState_builder.add_port_states();
   SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
@@ -363,13 +375,6 @@ TEST(ovs_dataplane_test_cases, 1_port_NEIGHBOR_CREATE_UPDATE)
 
   // fill in subnet state structs
   aca_test_create_default_subnet_state(new_subnet_states);
-
-  // delete br-int and br-tun bridges
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-int", not_care_culminative_time, overall_rc);
-
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-tun", not_care_culminative_time, overall_rc);
 
   // NEIGHBOR_CREATE_UPDATE
   GoalStateOperationReply gsOperationalReply;
@@ -410,6 +415,18 @@ TEST(ovs_dataplane_test_cases, 1_port_CREATE_plus_NEIGHBOR_CREATE_UPDATE)
   string cmd_string;
   int overall_rc;
 
+  // delete br-int and br-tun bridges
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-int", not_care_culminative_time, overall_rc);
+
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-tun", not_care_culminative_time, overall_rc);
+
+  // create and setup br-int and br-tun bridges, and their patch ports
+  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
   GoalState GoalState_builder;
   PortState *new_port_states = GoalState_builder.add_port_states();
   SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
@@ -446,13 +463,6 @@ TEST(ovs_dataplane_test_cases, 1_port_CREATE_plus_NEIGHBOR_CREATE_UPDATE)
           PortConfiguration_builder2->add_fixed_ips();
   FixedIp_builder2->set_subnet_id(subnet_id_1);
   FixedIp_builder2->set_ip_address(vip_address_3);
-
-  // delete br-int and br-tun bridges
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-int", not_care_culminative_time, overall_rc);
-
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-tun", not_care_culminative_time, overall_rc);
 
   // set demo mode
   bool previous_demo_mode = g_demo_mode;
@@ -507,6 +517,18 @@ TEST(ovs_dataplane_test_cases, 2_ports_CREATE_test_traffic)
   string cmd_string;
   int overall_rc;
 
+  // delete br-int and br-tun bridges
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-int", not_care_culminative_time, overall_rc);
+
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-tun", not_care_culminative_time, overall_rc);
+
+  // create and setup br-int and br-tun bridges, and their patch ports
+  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
   GoalState GoalState_builder;
   PortState *new_port_states = GoalState_builder.add_port_states();
   SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
@@ -537,13 +559,6 @@ TEST(ovs_dataplane_test_cases, 2_ports_CREATE_test_traffic)
 
   // fill in subnet state structs
   aca_test_create_default_subnet_state(new_subnet_states);
-
-  // delete br-int and br-tun bridges
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-int", not_care_culminative_time, overall_rc);
-
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-tun", not_care_culminative_time, overall_rc);
 
   // set demo mode
   bool previous_demo_mode = g_demo_mode;
@@ -613,7 +628,20 @@ TEST(ovs_dataplane_test_cases, 10_ports_CREATE)
 {
   string port_name_postfix = "11111111-2222-3333-4444-555555555555";
   string ip_address_prefix = "10.0.0.";
-  int rc;
+  ulong not_care_culminative_time = 0;
+  int overall_rc;
+
+  // delete br-int and br-tun bridges
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-int", not_care_culminative_time, overall_rc);
+
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-tun", not_care_culminative_time, overall_rc);
+
+  // create and setup br-int and br-tun bridges, and their patch ports
+  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
 
   GoalState GoalState_builder;
   PortState *new_port_states;
@@ -628,7 +656,6 @@ TEST(ovs_dataplane_test_cases, 10_ports_CREATE)
     new_port_states = GoalState_builder.add_port_states();
     new_port_states->set_operation_type(OperationType::CREATE);
 
-    // this will allocate new PortConfiguration, may need to free it later
     PortConfiguration *PortConfiguration_builder =
             new_port_states->mutable_configuration();
     PortConfiguration_builder->set_format_version(1);
@@ -658,9 +685,10 @@ TEST(ovs_dataplane_test_cases, 10_ports_CREATE)
   bool previous_demo_mode = g_demo_mode;
   g_demo_mode = false;
 
-  GoalStateOperationReply gsOperationalReply;
-  rc = Aca_Comm_Manager::get_instance().update_goal_state(GoalState_builder, gsOperationalReply);
-  EXPECT_NE(rc, EXIT_SUCCESS);
+  GoalStateOperationReply gsOperationReply;
+  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
+          GoalState_builder, gsOperationReply);
+  EXPECT_EQ(overall_rc, EINPROGRESS);
 
   g_demo_mode = previous_demo_mode;
 
@@ -669,18 +697,108 @@ TEST(ovs_dataplane_test_cases, 10_ports_CREATE)
 
   for (int i = 0; i < PORTS_TO_CREATE; i++) {
     ACA_LOG_DEBUG("Port State(%d) took: %u nanoseconds or %u milliseconds\n", i,
-                  gsOperationalReply.operation_statuses(i).state_elapse_time(),
-                  gsOperationalReply.operation_statuses(i).state_elapse_time() / 1000000);
+                  gsOperationReply.operation_statuses(i).state_elapse_time(),
+                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000000);
 
-    total_port_create_time +=
-            gsOperationalReply.operation_statuses(i).state_elapse_time();
+    total_port_create_time += gsOperationReply.operation_statuses(i).state_elapse_time();
   }
 
   ulong average_port_create_time = total_port_create_time / PORTS_TO_CREATE;
 
-  ACA_LOG_DEBUG("Average Port Create of %d took: %lu nanoseconds or %lu milliseconds\n",
-                PORTS_TO_CREATE, average_port_create_time,
-                average_port_create_time / 1000000);
+  ACA_LOG_INFO("Average Port Create of %d took: %lu nanoseconds or %lu milliseconds\n",
+               PORTS_TO_CREATE, average_port_create_time,
+               average_port_create_time / 1000000);
+
+  ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u nanoseconds or %u milliseconds\n",
+               gsOperationReply.message_total_operation_time(),
+               gsOperationReply.message_total_operation_time() / 1000000);
+}
+
+TEST(ovs_dataplane_test_cases, 10_l2_neighbor_CREATE)
+{
+  string port_name_postfix = "11111111-2222-3333-4444-555555555555";
+  string ip_address_prefix = "10.0.0.";
+  string remote_ip_address_prefix = "172.0.0.";
+  ulong not_care_culminative_time = 0;
+  int overall_rc;
+
+  // delete br-int and br-tun bridges
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-int", not_care_culminative_time, overall_rc);
+
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-tun", not_care_culminative_time, overall_rc);
+
+  // create and setup br-int and br-tun bridges, and their patch ports
+  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  GoalState GoalState_builder;
+  NeighborState *new_neighbor_states;
+  SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
+
+  const int L2_NEIGHBOR_TO_CREATE = 10;
+
+  for (int i = 0; i < L2_NEIGHBOR_TO_CREATE; i++) {
+    string i_string = std::to_string(i);
+    string port_name = i_string + port_name_postfix;
+
+    new_neighbor_states = GoalState_builder.add_neighbor_states();
+    new_neighbor_states->set_operation_type(OperationType::CREATE);
+
+    NeighborConfiguration *NeighborConfiguration_builder =
+            new_neighbor_states->mutable_configuration();
+    NeighborConfiguration_builder->set_format_version(1);
+    NeighborConfiguration_builder->set_revision_number(1);
+    NeighborConfiguration_builder->set_neighbor_type(NeighborType::L2);
+
+    NeighborConfiguration_builder->set_project_id(project_id);
+    NeighborConfiguration_builder->set_vpc_id(vpc_id_1);
+    NeighborConfiguration_builder->set_name(port_name);
+    NeighborConfiguration_builder->set_mac_address(vmac_address_1);
+    NeighborConfiguration_builder->set_host_ip_address(remote_ip_address_prefix + i_string);
+
+    NeighborConfiguration_FixedIp *FixedIp_builder =
+            NeighborConfiguration_builder->add_fixed_ips();
+    FixedIp_builder->set_subnet_id(subnet_id_1);
+    FixedIp_builder->set_ip_address(ip_address_prefix + i_string);
+  }
+
+  // fill in the subnet state structs
+  aca_test_create_default_subnet_state(new_subnet_states);
+
+  bool previous_demo_mode = g_demo_mode;
+  g_demo_mode = false;
+
+  GoalStateOperationReply gsOperationReply;
+  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
+          GoalState_builder, gsOperationReply);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+
+  g_demo_mode = previous_demo_mode;
+
+  // calculate the average latency
+  ulong total_neighbor_create_time = 0;
+
+  for (int i = 0; i < L2_NEIGHBOR_TO_CREATE; i++) {
+    ACA_LOG_DEBUG("Neighbor State(%d) took: %u nanoseconds or %u milliseconds\n",
+                  i, gsOperationReply.operation_statuses(i).state_elapse_time(),
+                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000000);
+
+    total_neighbor_create_time +=
+            gsOperationReply.operation_statuses(i).state_elapse_time();
+  }
+
+  ulong average_neighbor_create_time = total_neighbor_create_time / L2_NEIGHBOR_TO_CREATE;
+
+  ACA_LOG_INFO("Average L2 Neighbor Create of %d took: %lu nanoseconds or %lu milliseconds\n",
+               L2_NEIGHBOR_TO_CREATE, average_neighbor_create_time,
+               average_neighbor_create_time / 1000000);
+
+  ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u nanoseconds or %u milliseconds\n",
+               gsOperationReply.message_total_operation_time(),
+               gsOperationReply.message_total_operation_time() / 1000000);
 }
 
 TEST(ovs_dataplane_test_cases, DISABLED_2_ports_CREATE_test_traffic_MASTER)
@@ -695,6 +813,11 @@ TEST(ovs_dataplane_test_cases, DISABLED_2_ports_CREATE_test_traffic_MASTER)
 
   ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
           "del-br br-tun", not_care_culminative_time, overall_rc);
+
+  // create and setup br-int and br-tun bridges, and their patch ports
+  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
 
   GoalState GoalState_builder;
   PortState *new_port_states = GoalState_builder.add_port_states();
@@ -875,12 +998,17 @@ TEST(ovs_dataplane_test_cases, DISABLED_2_ports_CREATE_test_traffic_SLAVE)
   string cmd_string;
   int overall_rc;
 
-  // delete and add br-int and br-tun bridges to clear everything
+  // delete br-int and br-tun bridges
   ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
           "del-br br-int", not_care_culminative_time, overall_rc);
 
   ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
           "del-br br-tun", not_care_culminative_time, overall_rc);
+
+  // create and setup br-int and br-tun bridges, and their patch ports
+  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
 
   GoalState GoalState_builder;
   PortState *new_port_states = GoalState_builder.add_port_states();


### PR DESCRIPTION
This PR includes the following changes:

- Remove error logging for port create pending status return
- Optimized port create processing by removing ovs bridge check at the begining
- Added port create parallel programming time data
- Added new test case 10_l2_neighbor_CREATE for performance measurement