### PR TITLE
[Enhancement] Remove the needed for neighbor host DVR mac in L3 neighbor configuration

### DIFF
--- a/include/aca_config.h
+++ b/include/aca_config.h
@@ -18,4 +18,9 @@
 #define MAX_PORT_SCAN_RETRY 300
 #define PORT_SCAN_SLEEP_INTERVAL 1000 // 1000ms = 1s
 
+// prefix to indicate it is an Alcor Distributed Router host mac
+// (aka host DVR mac)
+#define HOST_DVR_MAC_PREFIX "fe:16:11:"
+#define HOST_DVR_MAC_MATCH HOST_DVR_MAC_PREFIX + "00:00:00/ff:ff:ff:00:00:00"
+
 #endif // #ifndef ACA_CONFIG_H

--- a/src/README.md
+++ b/src/README.md
@@ -4,18 +4,20 @@ Next Generation Cloud Network Control Agent
 # Summary
 Source code folder:
 
-- Comm: Library for communication with network controllers and transit daemon
+- comm: Library for communication with Alcor controllers, includes gRPC and MQ implementation
+- dhcp: DHCP server implementation
+- dp_abstraction: Data plane abstraction layer implementation
 - grpc: Auto generated source codes and library for gRPC interface with Alcor Controllers
 - net_config: Library for configurating host networking components
+- ovs: OVS data plane implementation
 - proto3: Auto generated source codes and library for proto3 scheme for communication with Alcor Controllers
-- transit_rpc: Library for RPC interface with transit daemon
 - test: Unit and integration test code
 
 # Build and Execution Instructions using Dockerfile
 Since the Alcor Control Agent relies on a few external dependencies, Dockerfile was used for fast build and test environment setup.
 
 ## Setting up a Development Environment
-The Alcor Control Agent project currently uses cmake for building. It includes the Alcor controller and Transit submodules to consume the needed proto3 schemas and RPC definitions.
+The Alcor Control Agent project currently uses cmake for building. It includes the Alcor controller submodule to consume the needed proto3 schemas and gRPC definitions.
 
 To set up your local development environment, we recommend to use fork-and-branch git workflow.
 
@@ -65,6 +67,14 @@ Assuming alcor-control-agent was cloned into ~/dev/alcor-control-agent directory
 cd ~/dev/alcor-control-agent
 ./build/build.sh
 ```
+
+## You can also setup a physical machine or VM to compile the alcor-control-agent
+Assuming alcor-control-agent was cloned into ~/dev/alcor-control-agent directory:
+```Shell
+cd ~/dev/alcor-control-agent
+./build/aca-machine-init.sh
+```
+
 ## Running alcor-control-agent and tests
 You can run the test (optional):
 ```Shell

--- a/src/aca_main.cpp
+++ b/src/aca_main.cpp
@@ -33,8 +33,7 @@ static char EMPTY_STRING[] = "";
 static char BROKER_LIST[] = "172.17.0.1:9092";
 static char KAFKA_TOPIC[] = "Host-ts-1";
 static char KAFKA_GROUP_ID[] = "test-group-id";
-static char LOCALHOST[] = "localhost";
-static char UDP_PROTOCOL[] = "udp";
+static char GRPC_SERVER_PORT[] = "50001";
 static char OFCTL_COMMAND[] = "monitor";
 static char OFCTL_TARGET[] = "br-int";
 
@@ -47,8 +46,7 @@ GoalStateProvisionerImpl *g_grpc_server = NULL;
 string g_broker_list = EMPTY_STRING;
 string g_kafka_topic = EMPTY_STRING;
 string g_kafka_group_id = EMPTY_STRING;
-string g_rpc_server = EMPTY_STRING;
-string g_rpc_protocol = EMPTY_STRING;
+string g_grpc_server_port = EMPTY_STRING;
 string g_ofctl_command = EMPTY_STRING;
 string g_ofctl_target = EMPTY_STRING;
 string g_ofctl_options = EMPTY_STRING;
@@ -129,11 +127,8 @@ int main(int argc, char *argv[])
     case 'g':
       g_kafka_group_id = optarg;
       break;
-    case 's':
-      g_rpc_server = optarg;
-      break;
     case 'p':
-      g_rpc_protocol = optarg;
+      g_grpc_server_port = optarg;
       break;
     case 'c':
       g_ofctl_command = optarg;
@@ -156,8 +151,7 @@ int main(int argc, char *argv[])
               "\t\t[-b kafka broker list]\n"
               "\t\t[-h kafka host topic to listen]\n"
               "\t\t[-g kafka group id]\n"
-              "\t\t[-s transitd RPC server]\n"
-              "\t\t[-p transitd RPC protocol]\n"
+              "\t\t[-p gRPC server port\n"
               "\t\t[-c ofctl command]\n"
               "\t\t[-t ofctl target]\n"
               "\t\t[-m enable demo mode]\n"
@@ -177,11 +171,8 @@ int main(int argc, char *argv[])
   if (g_kafka_group_id == EMPTY_STRING) {
     g_kafka_group_id = KAFKA_GROUP_ID;
   }
-  if (g_rpc_server == EMPTY_STRING) {
-    g_rpc_server = LOCALHOST;
-  }
-  if (g_rpc_protocol == EMPTY_STRING) {
-    g_rpc_protocol = UDP_PROTOCOL;
+  if (g_grpc_server_port == EMPTY_STRING) {
+    g_grpc_server_port = GRPC_SERVER_PORT;
   }
   if (g_ofctl_command == EMPTY_STRING) {
     g_ofctl_command = OFCTL_COMMAND;

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -30,7 +30,7 @@
 #include "aca_log.h"
 #include "aca_grpc.h"
 
-static char GRPC_SERVER_ADDRESS[] = "0.0.0.0:50001";
+extern string g_grpc_server_port;
 
 using namespace alcor::schema;
 using aca_comm_manager::Aca_Comm_Manager;
@@ -86,9 +86,11 @@ Status GoalStateProvisionerImpl::PushNetworkResourceStatesStream(
 void GoalStateProvisionerImpl::RunServer()
 {
   ServerBuilder builder;
+  string GRPC_SERVER_ADDRESS = "0.0.0.0:" + g_grpc_server_port;
   builder.AddListeningPort(GRPC_SERVER_ADDRESS, grpc::InsecureServerCredentials());
   builder.RegisterService(this);
   std::unique_ptr<Server> server(builder.BuildAndStart());
-  ACA_LOG_INFO("Streaming capable GRPC server listening on %s\n", GRPC_SERVER_ADDRESS);
+  ACA_LOG_INFO("Streaming capable GRPC server listening on %s\n",
+               GRPC_SERVER_ADDRESS.c_str());
   server->Wait();
 }

--- a/src/ovs/aca_ovs_l2_programmer.cpp
+++ b/src/ovs/aca_ovs_l2_programmer.cpp
@@ -189,10 +189,6 @@ int ACA_OVS_L2_Programmer::configure_port(const string vpc_id, const string port
     throw std::invalid_argument("tunnel_id is 0");
   }
 
-  if (overall_rc != EXIT_SUCCESS) {
-    throw std::runtime_error("Invalid environment with br-int and br-tun");
-  }
-
   // TODO: if ovs_port already exist in vlan manager, that means it is a duplicated
   // port CREATE operation, we have the following options to handle it:
   // 1. Reject call with error message
@@ -277,10 +273,6 @@ int ACA_OVS_L2_Programmer::create_update_neighbor_port(const string vpc_id,
 
   if (tunnel_id == 0) {
     throw std::invalid_argument("tunnel_id is 0");
-  }
-
-  if (overall_rc != EXIT_SUCCESS) {
-    throw std::runtime_error("Invalid environment with br-int and br-tun");
   }
 
   string outport_name = aca_get_outport_name(network_type, remote_host_ip);

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -14,6 +14,7 @@
 
 #include "aca_log.h"
 #include "aca_util.h"
+#include "aca_config.h"
 #include "aca_net_config.h"
 #include "aca_vlan_manager.h"
 #include "aca_ovs_l2_programmer.h"
@@ -26,11 +27,6 @@
 #include <arpa/inet.h>
 
 #define HEX_IP_BUFFER_SIZE 12
-
-// prefix to indicate it is an Alcor Distributed Router host mac
-// (aka host DVR mac)
-#define HOST_DVR_MAC_PREFIX "fe:16:11:"
-#define HOST_DVR_MAC_MATCH HOST_DVR_MAC_PREFIX + "00:00:00/ff:ff:ff:00:00:00"
 
 using namespace std;
 using namespace aca_vlan_manager;

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -30,7 +30,7 @@
 // prefix to indicate it is an Alcor Distributed Router host mac
 // (aka host DVR mac)
 #define HOST_DVR_MAC_PREFIX "fe:16:11:"
-#define HOST_DVR_MAC_MATCH HOST_DVR_MAC_PREFIX + ":00:00:00/ff:ff:ff:00:00:00"
+#define HOST_DVR_MAC_MATCH HOST_DVR_MAC_PREFIX + "00:00:00/ff:ff:ff:00:00:00"
 
 using namespace std;
 using namespace aca_vlan_manager;

--- a/test/func_tests/gs_tests.cpp
+++ b/test/func_tests/gs_tests.cpp
@@ -183,7 +183,7 @@ class GoalStateProvisionerClient {
                  sync_call_ns, sync_call_ns / 1000000);
 
     if (!status.ok()) {
-      ACA_LOG_ERROR("RPC call failed");
+      ACA_LOG_ERROR("RPC call failed\n");
     }
   }
 
@@ -415,7 +415,7 @@ class GoalStateProvisionerClient {
                  (send_goalstate_ns - g_total_ACA_Message_time.load()) / 1000000);
 
     if (!status.ok()) {
-      ACA_LOG_ERROR("RPC call failed");
+      ACA_LOG_ERROR("RPC call failed\n");
     }
   }
 

--- a/test/gtest/aca_tests.cpp
+++ b/test/gtest/aca_tests.cpp
@@ -37,6 +37,7 @@ using namespace aca_dhcp_programming_if;
 
 // Defines
 #define ACALOGNAME "AlcorControlAgentTest"
+#define HOST_DVR_MAC_PREFIX "fe:16:11:"
 
 static char EMPTY_STRING[] = "";
 static char VALID_STRING[] = "VALID_STRING";
@@ -69,8 +70,8 @@ static string subnet1_gw_ip = "10.10.0.1";
 static string subnet2_gw_ip = "10.10.1.1";
 static string subnet1_gw_mac = "fa:16:3e:d7:f2:11";
 static string subnet2_gw_mac = "fa:16:3e:d7:f2:21";
-static string host1_dvr_mac_address = "fa:16:3e:d7:f2:01";
-static string host2_dvr_mac_address = "fa:16:3e:d7:f2:02";
+static string host1_dvr_mac_address = HOST_DVR_MAC_PREFIX + string("d7:f2:01");
+static string host2_dvr_mac_address = HOST_DVR_MAC_PREFIX + string("d7:f2:02");
 static NetworkType vxlan_type = NetworkType::VXLAN;
 
 // Global variables

--- a/test/gtest/aca_tests.cpp
+++ b/test/gtest/aca_tests.cpp
@@ -14,8 +14,8 @@
 
 #include "aca_log.h"
 #include "aca_util.h"
+#include "aca_config.h"
 #include "aca_ovs_l2_programmer.h"
-// #include "aca_ovs_l3_programmer.h"
 #include "aca_comm_mgr.h"
 #include "aca_net_config.h"
 #include "gtest/gtest.h"
@@ -37,7 +37,6 @@ using namespace aca_dhcp_programming_if;
 
 // Defines
 #define ACALOGNAME "AlcorControlAgentTest"
-#define HOST_DVR_MAC_PREFIX "fe:16:11:"
 
 static char EMPTY_STRING[] = "";
 static char VALID_STRING[] = "VALID_STRING";


### PR DESCRIPTION
Using DVR mac prefix (e.g., fe:16:11:) together with internal vlan ID based on incoming tunnel ID, we can determine the incoming packet is coming from a neighbor host DVR and restore src mac to the port's gateway MAC. This removes the need of neighbor host DVR mac for L3 neighbor configuration. 

This change includes:
1. define a mac prefix to indicate it is a host dvr mac (aca_config.h)
2. update L3 neighbor configuration handling (aca_ovs_l3_programming.cpp)
3. update routing test to confirm passing with new algorithm (aca_test.cpp) 

Thanks to the suggestion from https://github.com/futurewei-cloud/alcor/issues/375