### PR TITLE
[Hotfix] standardize mac address for DHCP and improve logging

### DIFF
--- a/include/aca_dhcp_server.h
+++ b/include/aca_dhcp_server.h
@@ -164,6 +164,7 @@ class ACA_Dhcp_Server : public aca_dhcp_programming_if::ACA_Dhcp_Programming_Int
   void _validate_ipv4_address(const char *ip_address);
   void _validate_ipv6_address(const char *ip_address);
   int _validate_dhcp_entry(dhcp_config *dhcp_cfg_in);
+  void _standardize_mac_address(string &mac_string);
 
   /**************** Data plane operations *********************/
   int _validate_dhcp_message(dhcp_message *dhcpmsg);
@@ -198,7 +199,8 @@ class ACA_Dhcp_Server : public aca_dhcp_programming_if::ACA_Dhcp_Programming_Int
   std::unordered_map<std::string, dhcp_entry_data> *_dhcp_db;
   std::mutex _dhcp_db_mutex;
 
-  void (aca_dhcp_server::ACA_Dhcp_Server ::*_parse_dhcp_msg_ops[DHCP_MSG_MAX])(uint32_t in_port, dhcp_message *dhcpmsg);
+  void (aca_dhcp_server::ACA_Dhcp_Server ::*_parse_dhcp_msg_ops[DHCP_MSG_MAX])(
+          uint32_t in_port, dhcp_message *dhcpmsg);
 };
 
 } // namespace aca_dhcp_server

--- a/src/comm/aca_comm_mgr.cpp
+++ b/src/comm/aca_comm_mgr.cpp
@@ -208,8 +208,17 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
     fprintf(stdout, "current_SubnetConfiguration.revision_number(): %d\n",
             current_SubnetConfiguration.revision_number());
 
+    fprintf(stdout, "current_SubnetConfiguration.request_id(): %s\n",
+            current_SubnetConfiguration.request_id().c_str());
+
     fprintf(stdout, "current_SubnetConfiguration.id(): %s\n",
             current_SubnetConfiguration.id().c_str());
+
+    fprintf(stdout, "current_SubnetConfiguration.message_type(): %d\n",
+            current_SubnetConfiguration.message_type());
+
+    fprintf(stdout, "current_SubnetConfiguration.network_type(): %d\n",
+            current_SubnetConfiguration.network_type());
 
     fprintf(stdout, "current_SubnetConfiguration.project_id(): %s\n",
             current_SubnetConfiguration.project_id().c_str());
@@ -259,6 +268,9 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
 
     fprintf(stdout, "current_PortConfiguration.revision_number(): %d\n",
             current_PortConfiguration.revision_number());
+
+    fprintf(stdout, "current_PortConfiguration.request_id(): %s\n",
+            current_PortConfiguration.request_id().c_str());
 
     fprintf(stdout, "current_PortConfiguration.message_type(): %d\n",
             current_PortConfiguration.message_type());
@@ -329,6 +341,12 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
     fprintf(stdout, "current_NeighborConfiguration.id(): %s\n",
             current_NeighborConfiguration.id().c_str());
 
+    fprintf(stdout, "current_NeighborConfiguration.request_id(): %s\n",
+            current_NeighborConfiguration.request_id().c_str());
+
+    fprintf(stdout, "current_NeighborConfiguration.message_type(): %d\n",
+            current_NeighborConfiguration.message_type());
+
     fprintf(stdout, "current_NeighborConfiguration.project_id(): %s\n",
             current_NeighborConfiguration.project_id().c_str());
 
@@ -365,7 +383,7 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
   }
 
   for (int i = 0; i < parsed_struct.security_group_states_size(); i++) {
-    fprintf(stdout, "parsed_struct.neighbor_states(%d).operation_type(): %s\n", i,
+    fprintf(stdout, "parsed_struct.security_group_states(%d).operation_type(): %s\n", i,
             aca_get_operation_string(parsed_struct.security_group_states(i).operation_type()));
 
     SecurityGroupConfiguration current_SecurityGroupConfiguration =
@@ -377,8 +395,14 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
     fprintf(stdout, "current_SecurityGroupConfiguration.revision_number(): %d\n",
             current_SecurityGroupConfiguration.revision_number());
 
+    fprintf(stdout, "current_SecurityGroupConfiguration.request_id(): %s\n",
+            current_SecurityGroupConfiguration.request_id().c_str());
+
     fprintf(stdout, "current_SecurityGroupConfiguration.id(): %s\n",
             current_SecurityGroupConfiguration.id().c_str());
+
+    fprintf(stdout, "current_SecurityGroupConfiguration.message_type(): %d\n",
+            current_SecurityGroupConfiguration.message_type());
 
     fprintf(stdout, "current_SecurityGroupConfiguration.project_id(): %s\n",
             current_SecurityGroupConfiguration.project_id().c_str());
@@ -418,7 +442,50 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
     printf("\n");
   }
 
-  // TODO: add the print out of DHCP message
+  for (int i = 0; i < parsed_struct.dhcp_states_size(); i++) {
+    fprintf(stdout, "parsed_struct.dhcp_states(%d).operation_type(): %s\n", i,
+            aca_get_operation_string(parsed_struct.dhcp_states(i).operation_type()));
+
+    DHCPConfiguration current_DHCPConfiguration =
+            parsed_struct.dhcp_states(i).configuration();
+
+    fprintf(stdout, "current_DHCPConfiguration.format_version(): %d\n",
+            current_DHCPConfiguration.format_version());
+
+    fprintf(stdout, "current_DHCPConfiguration.revision_number(): %d\n",
+            current_DHCPConfiguration.revision_number());
+
+    fprintf(stdout, "current_DHCPConfiguration.request_id(): %s\n",
+            current_DHCPConfiguration.request_id().c_str());
+
+    fprintf(stdout, "current_DHCPConfiguration.subnet_id(): %s\n",
+            current_DHCPConfiguration.subnet_id().c_str());
+
+    fprintf(stdout, "current_DHCPConfiguration.mac_address(): %s\n",
+            current_DHCPConfiguration.mac_address().c_str());
+
+    fprintf(stdout, "current_DHCPConfiguration.ipv4_address(): %s\n",
+            current_DHCPConfiguration.ipv4_address().c_str());
+
+    fprintf(stdout, "current_DHCPConfiguration.ipv6_address(): %s\n",
+            current_DHCPConfiguration.ipv6_address().c_str());
+
+    fprintf(stdout, "current_DHCPConfiguration.port_host_name(): %s \n",
+            current_DHCPConfiguration.port_host_name().c_str());
+
+    for (int j = 0; j < current_DHCPConfiguration.extra_dhcp_options_size(); j++) {
+      fprintf(stdout, "current_DHCPConfiguration.extra_dhcp_options(%d): name: %s, value %s \n",
+              j, current_DHCPConfiguration.extra_dhcp_options(j).name().c_str(),
+              current_DHCPConfiguration.extra_dhcp_options(j).value().c_str());
+    }
+
+    for (int j = 0; j < current_DHCPConfiguration.dns_entry_list_size(); j++) {
+      fprintf(stdout, "current_DHCPConfiguration.dns_entry_list(%d): entry %s \n",
+              j, current_DHCPConfiguration.dns_entry_list(j).entry().c_str());
+    }
+
+    printf("\n");
+  }
 
   for (int i = 0; i < parsed_struct.router_states_size(); i++) {
     fprintf(stdout, "parsed_struct.router_states(%d).operation_type(): %s\n", i,
@@ -432,6 +499,9 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
 
     fprintf(stdout, "current_RouterConfiguration.revision_number(): %d\n",
             current_RouterConfiguration.revision_number());
+
+    fprintf(stdout, "current_RouterConfiguration.request_id(): %s\n",
+            current_RouterConfiguration.request_id().c_str());
 
     fprintf(stdout, "current_RouterConfiguration.id(): %s\n",
             current_RouterConfiguration.id().c_str());

--- a/src/ovs/aca_ovs_control.cpp
+++ b/src/ovs/aca_ovs_control.cpp
@@ -199,6 +199,7 @@ void ACA_OVS_Control::parse_packet(uint32_t in_port, void *packet)
   int size_udp = ntohs(udp->uh_ulen);
 
   if (size_udp < 20) {
+    ACA_LOG_ERROR("size_udp < 20: %d\n", size_udp);
     return;
   } else {
     int udp_sport = ntohs(udp->uh_sport);
@@ -212,9 +213,7 @@ void ACA_OVS_Control::parse_packet(uint32_t in_port, void *packet)
     /* compute udp payload (datagram) size */
     size_payload = ntohs(ip->ip_len) - (size_ip + 8);
 
-    /*
-        * Print payload data.
-        */
+    /* Print payload data. */
     if (size_payload > 0) {
       ACA_LOG_INFO("   Payload (%d bytes):\n", size_payload);
       print_payload(payload, size_payload);
@@ -223,8 +222,8 @@ void ACA_OVS_Control::parse_packet(uint32_t in_port, void *packet)
     /* dhcp message procedure */
     if (udp_sport == 68 && udp_dport == 67) {
       ACA_LOG_INFO("   Message Type: DHCP\n");
-      aca_dhcp_server::ACA_Dhcp_Server::get_instance().dhcps_recv(in_port, 
-              const_cast<unsigned char *>(payload));
+      aca_dhcp_server::ACA_Dhcp_Server::get_instance().dhcps_recv(
+              in_port, const_cast<unsigned char *>(payload));
     }
   }
 }


### PR DESCRIPTION
__Bug Description__
Mac addresses have a few valid forms and may come in upper or lower case. Standardizing mac address for DHCP processing is needed to enable E2E integration of Alcor+Openstack because the goal state message received by ACA could be in the format of AA-BB-CC-DD-EE-FF but the received DHCP packet mac address could be aa:bb:cc:dd:ee:ff. 

__Proposed Change__
The change is to standardize the mac address to aa:bb:cc:dd:ee:ff before add/remove/update/find in the DHCP database. Additional log statements are also added to improve diagnosability for the DHCP E2E.