### PR TITLE
Adding container based ACA unit test with build for cross platform development

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,13 +1,21 @@
 FROM ubuntu:18.04
-RUN echo "--- installing mizar dependencies ---" && \
+RUN echo "1--- installing common dependencies ---" && \
     apt-get update -y && apt-get install -y \
     rpcbind \
     rsyslog \
     build-essential \
+    make \
+    g++ \
+    unzip \
+    cmake \
     clang-7 \
     llvm-7 \
     libelf-dev \
-    #openvswitch-switch \
+    doxygen \
+    zlib1g-dev \
+    libssl-dev \
+    libboost-program-options-dev \
+    libboost-all-dev \
     iproute2  \
     net-tools \
     iputils-ping \
@@ -22,29 +30,31 @@ RUN echo "--- installing mizar dependencies ---" && \
     autoconf \
     automake \
     dh-autoreconf \
+    pkg-config \
     libtool
 RUN pip3 install httpserver netaddr
 
-ENV OVS_RELEASE_TAG branch-2.12
-RUN echo "--- installing openvswitch dependancies ---" && \
-    git clone -b ${OVS_RELEASE_TAG} https://github.com/openvswitch/ovs.git /var/local/git/openvswitch && \
-    cd /var/local/git/openvswitch && \    
-    ./boot.sh && \
-    ./configure --prefix=/usr/local --localstatedir=/var --sysconfdir=/etc --enable-shared && \
+# this layer is consuming about 406MB, can try to optimize 
+RUN echo "2--- installing librdkafka ---" && \
+    apt-get install -y --no-install-recommends\
+    librdkafka-dev \
+    && apt-get clean
+
+RUN echo "3--- installing cppkafka ---" && \
+    git clone https://github.com/mfontanini/cppkafka.git /var/local/git/cppkafka && \
+    cd /var/local/git/cppkafka && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
     make && \
     make install && \
-    cp /var/local/git/openvswitch/lib/vconn-provider.h /usr/local/include/openvswitch/vconn-provider.h && \
-    rm -rf \var\local\git\openvswitch
-
-RUN echo "--- installing grpc dependencies ---" && \
-    apt-get install -y \
-    cmake libssl-dev \
-    autoconf git pkg-config \
-    automake libtool make g++ unzip 
+    ldconfig && \
+    rm -rf /var/local/git/cppkafka && \
+    cd ~
 
 # installing grpc and its dependencies
 ENV GRPC_RELEASE_TAG v1.24.x
-RUN echo "--- cloning grpc repo ---" && \
+RUN echo "4--- cloning grpc repo ---" && \
     git clone -b ${GRPC_RELEASE_TAG} https://github.com/grpc/grpc /var/local/git/grpc && \
     cd /var/local/git/grpc && \
     git submodule update --init && \
@@ -77,26 +87,22 @@ RUN echo "--- cloning grpc repo ---" && \
     cmake -Dgtest_build_samples=ON -DBUILD_SHARED_LIBS=ON . && \
     make && \
     make install && \
-    rm -rf /var/local/git/grpc
+    rm -rf /var/local/git/grpc && \
+    cd ~
 
-# this layer is consuming about 406MB, can try to optimize 
-RUN echo "--- installing librdkafka ---" && \
-    apt-get install -y --no-install-recommends\
-    librdkafka-dev \
-    doxygen \
-    libssl-dev \
-    zlib1g-dev \
-    libboost-program-options-dev \
-    libboost-all-dev \
-    && apt-get clean
-
-RUN echo "--- installing cppkafka ---" && \
-    git clone https://github.com/mfontanini/cppkafka.git /var/local/git/cppkafka && \
-    cd /var/local/git/cppkafka && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
+ENV OVS_RELEASE_TAG branch-2.12
+RUN echo "5--- installing openvswitch dependancies ---" && \
+    git clone -b ${OVS_RELEASE_TAG} https://github.com/openvswitch/ovs.git /var/local/git/openvswitch && \
+    cd /var/local/git/openvswitch && \
+    ./boot.sh && \
+    ./configure --prefix=/usr/local --localstatedir=/var --sysconfdir=/etc --enable-shared && \
     make && \
     make install && \
-    ldconfig && \
-    rm -rf /var/local/git/cppkafka
+    mkdir -p /usr/local/include/openvswitch && \
+    cp /var/local/git/openvswitch/lib/vconn-provider.h /usr/local/include/openvswitch/vconn-provider.h && \
+    rm -rf /var/local/git/openvswitch && \
+    cd ~
+
+ENV PATH=$PATH:/usr/local/share/openvswitch/scripts \
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,15 +1,63 @@
 #!/bin/bash
 
+BUILD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+echo "build path is $BUILD"
+
 # Initialize the needed mizar submodule
 git submodule update --init --recursive
 
 # Create and Start the build contrainer
-docker build -f build/Dockerfile -t aca_build0 .
-docker create -v $(pwd):/mnt/host/code -it --privileged --cap-add=NET_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --name a1 aca_build0:latest /bin/bash
+docker build -f $BUILD/Dockerfile -t aca_build0 .
+docker rm -f a1 || true
+docker create -v $BUILD/..:/mnt/host/code -it --privileged --cap-add=NET_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --name a1 aca_build0:latest /bin/bash
 docker start a1
 
 # Build mizar first
 # docker exec a1 bash -c "cd /mnt/host/code/mizar && make"
 
-# Build alcor control agent
-docker exec a1 bash -c "cd /mnt/host/code && cmake . && make"
+if [ "$1" != "test" ]; then
+  # Build alcor control agent
+  echo "--- building alcor-control-agent ---"
+  docker exec a1 bash -c "cd /mnt/host/code && cmake . && make"
+else
+  sed -i.bak -E 's/("add-br )([a-z]+-[a-z]+)(")/\1\2 -- set bridge \2 datapath_type=netdev\3/g' $BUILD/../src/ovs/aca_ovs_l2_programmer.cpp
+  # Build alcor control agent
+  echo "--- building alcor-control-agent pre test ---"
+  docker exec a1 bash -c "cd /mnt/host/code && cmake . && make"
+
+  echo "--- Start ACA Unit test ---"
+  echo "    --- rebuilding br-tun and br-int"
+  docker exec a1 bash -c ' \
+    ovs-ctl --delete-bridges stop && \
+    rm -rf /etc/openvswitch /usr/local/etc/openvswitch && \
+    mkdir -p /var/log/openvswitch && \
+    mkdir -p /etc/openvswitch && \
+    ovsdb-tool create /etc/openvswitch/conf.db /usr/local/share/openvswitch/vswitch.ovsschema && \
+    mkdir -p /var/run/openvswitch && \
+    ovsdb-server --remote=punix:/var/run/openvswitch/db.sock --remote=db:Open_vSwitch,Open_vSwitch,manager_options --pidfile --detach --log-file && \
+    ovs-vsctl --no-wait init && \
+    ovs-vswitchd --pidfile --detach --log-file && \
+    ovs-vsctl add-br br-int -- set bridge br-int datapath_type=netdev && \
+    ovs-vsctl add-br br-tun -- set bridge br-tun datapath_type=netdev && \
+    ovs-vsctl \
+    -- add-port br-int patch-tun \
+    -- set interface patch-tun type=patch options:peer=patch-int \
+    -- add-port br-tun patch-int \
+    -- set interface patch-int type=patch options:peer=patch-tun && \
+    ovs-ofctl add-flow br-tun "table=0, priority=1,in_port="patch-int" actions=resubmit(,2)" && \
+    ovs-ofctl add-flow br-tun "table=2, priority=0 actions=resubmit(,22)"'
+
+  echo "    --- running alcor-control-agent ---"
+  # sends output to null device, but stderr to console 
+  docker exec a1 bash -c "nohup /mnt/host/code/build/bin/AlcorControlAgent -d > /dev/null 2>&1 &"
+
+  echo "    --- Running unit test cases ---"
+  docker exec a1 bash -c "cd /mnt/host/code/build/tests && ./aca_tests && ./gs_tests"
+
+  mv -f $BUILD/../src/ovs/aca_ovs_l2_programmer.cpp.bak $BUILD/../src/ovs/aca_ovs_l2_programmer.cpp
+  # Build alcor control agent
+  echo "--- building alcor-control-agent post test ---"
+  docker exec a1 bash -c "cd /mnt/host/code && make"
+
+fi
+

--- a/src/ovs/aca_ovs_l2_programmer.cpp
+++ b/src/ovs/aca_ovs_l2_programmer.cpp
@@ -322,7 +322,7 @@ void ACA_OVS_L2_Programmer::execute_ovsdb_command(const std::string cmd_string,
 
   auto ovsdb_client_start = chrono::steady_clock::now();
 
-  string ovsdb_cmd_string = "/usr/bin/ovs-vsctl " + cmd_string;
+  string ovsdb_cmd_string = "ovs-vsctl " + cmd_string;
   int rc = aca_net_config::Aca_Net_Config::get_instance().execute_system_command(ovsdb_cmd_string);
 
   if (rc != EXIT_SUCCESS) {
@@ -349,7 +349,7 @@ void ACA_OVS_L2_Programmer::execute_openflow_command(const std::string cmd_strin
 
   auto openflow_client_start = chrono::steady_clock::now();
 
-  string openflow_cmd_string = "/usr/bin/ovs-ofctl " + cmd_string;
+  string openflow_cmd_string = "ovs-ofctl " + cmd_string;
   int rc = aca_net_config::Aca_Net_Config::get_instance().execute_system_command(openflow_cmd_string);
 
   if (rc != EXIT_SUCCESS) {


### PR DESCRIPTION
- To build in container: build.sh
- To build and run unit test: build.sh test

Note: No need to have OVS support in host, tested on Mac OsX and Linux host

Test Result:
[----------] Global test environment tear-down
[==========] 30 tests from 5 test suites ran. (17572 ms total)
[  PASSED  ] 30 tests.

  YOU HAVE 5 DISABLED TESTS

g_total_network_configuration_time = 45712663156 nanoseconds or 45712 milliseconds
g_total_update_GS_time = 4743972082 nanoseconds or 4743 milliseconds
Program exiting, cleaning up...
ACA_OVS_L2_Programmer::execute_openflow_command ---> Entering
Executing command: ovs-ofctl del-flows br-int "udp,udp_src=68,udp_dst=67"
Command succeeded!
 Elapsed time for system command took: 93502520 nanoseconds or 93 milliseconds.
Elapsed time for openflow client call took: 93765360 nanoseconds or 93 milliseconds. rc: 0
ACA_OVS_L2_Programmer::execute_openflow_command <--- Exiting, rc = 0
(NOT USED) Serialized protobuf string: "$27330ae4-b718-11ea-b3de-111111111111:$99d9d709-8478-4b46-9f3f-000000000000B$99d9d709-8478-4b46-9f3f-000000000000R
                                                                                                                                                          10.0.0.0/24X{b	10.10.0.1"fa:16:3e:d7:f2:11*�2$99d9d709-8478-4b46-9f3f-000000000000:$1b08a5bc-b718-11ea-b3de-111122223333B	portname1Jfa:16:3e:d7:f2:6cR
111.0.0.11Z1$27330ae4-b718-11ea-b3de-111111111111	11.0.0.11
(USING THIS) Serialized protobuf binary array: "$27330ae4-b718-11ea-b3de-111111111111:$99d9d709-8478-4b46-9f3f-000000000000B$99d9d709-8478-4b46-9f3f-000000000000R
                                                                                                                                                                  10.0.0.0/24X{b	10.10.0.1"fa:16:3e:d7:f2:11*�2$99d9d709-8478-4b46-9f3f-000000000000:$1b08a5bc-b718-11ea-b3de-111122223333B	portname1Jfa:16:3e:d7:f2:6cR
111.0.0.11Z1$27330ae4-b718-11ea-b3de-111111111111	11.0.0.11
Deserialize succeeded, comparing the content now...
All content matched!
