### PR TITLE
aca_memory_leak_test

### DIFF
--- a/include/aca_grpc.h
+++ b/include/aca_grpc.h
@@ -38,5 +38,9 @@ class GoalStateProvisionerImpl final : public GoalStateProvisioner::Service {
   PushNetworkResourceStatesStream(ServerContext *context,
                                   ServerReaderWriter<GoalStateOperationReply, GoalState> *stream) override;
 
+  Status ShutDownServer();
+  
   void RunServer();
+  private:
+  std::unique_ptr<Server> server;
 };

--- a/src/aca_main.cpp
+++ b/src/aca_main.cpp
@@ -96,7 +96,7 @@ static void aca_cleanup()
     g_grpc_server_thread = NULL;
     ACA_LOG_INFO("Cleaned up grpc server thread.\n");
   } else {
-    ACA_LOG_ERROR("Unable to call delete,grpc server thread pointer is null.\n");
+    ACA_LOG_ERROR("Unable to call delete, grpc server thread pointer is null.\n");
   }    
   ACA_LOG_CLOSE();
 }
@@ -192,7 +192,6 @@ int main(int argc, char *argv[])
   g_grpc_server_thread =
           new std::thread(std::bind(&GoalStateProvisionerImpl::RunServer, g_grpc_server));
   g_grpc_server_thread->detach();
-  //ACA_OVS_Control::get_instance().monitor("br-tun", "resume");
   
   ACA_OVS_Control::get_instance().monitor("br-int", "resume");
   

--- a/src/aca_main.cpp
+++ b/src/aca_main.cpp
@@ -83,6 +83,7 @@ static void aca_cleanup()
   }
 
   if (g_grpc_server != NULL) {
+    g_grpc_server->ShutDownServer();
     delete g_grpc_server;
     g_grpc_server = NULL;
     ACA_LOG_INFO("Cleaned up grpc server.\n");
@@ -90,6 +91,13 @@ static void aca_cleanup()
     ACA_LOG_ERROR("Unable to call delete, grpc server pointer is null.\n");
   }
 
+  if (g_grpc_server_thread != NULL){
+    delete g_grpc_server_thread;
+    g_grpc_server_thread = NULL;
+    ACA_LOG_INFO("Cleaned up grpc server thread.\n");
+  } else {
+    ACA_LOG_ERROR("Unable to call delete,grpc server thread pointer is null.\n");
+  }    
   ACA_LOG_CLOSE();
 }
 
@@ -179,12 +187,13 @@ int main(int argc, char *argv[])
   if (g_ofctl_target == EMPTY_STRING) {
     g_ofctl_target = OFCTL_TARGET;
   }
-
+	
   g_grpc_server = new GoalStateProvisionerImpl();
   g_grpc_server_thread =
           new std::thread(std::bind(&GoalStateProvisionerImpl::RunServer, g_grpc_server));
-
+  g_grpc_server_thread->detach();
   //ACA_OVS_Control::get_instance().monitor("br-tun", "resume");
+  
   ACA_OVS_Control::get_instance().monitor("br-int", "resume");
   
   MessageConsumer network_config_consumer(g_broker_list, g_kafka_group_id);

--- a/src/aca_main.cpp
+++ b/src/aca_main.cpp
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
   if (g_ofctl_target == EMPTY_STRING) {
     g_ofctl_target = OFCTL_TARGET;
   }
-  
+
   g_grpc_server = new GoalStateProvisionerImpl();
   g_grpc_server_thread =
           new std::thread(std::bind(&GoalStateProvisionerImpl::RunServer, g_grpc_server));

--- a/src/aca_main.cpp
+++ b/src/aca_main.cpp
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
   if (g_ofctl_target == EMPTY_STRING) {
     g_ofctl_target = OFCTL_TARGET;
   }
-	
+  
   g_grpc_server = new GoalStateProvisionerImpl();
   g_grpc_server_thread =
           new std::thread(std::bind(&GoalStateProvisionerImpl::RunServer, g_grpc_server));

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -96,7 +96,6 @@ void GoalStateProvisionerImpl::RunServer()
   string GRPC_SERVER_ADDRESS = "0.0.0.0:" + g_grpc_server_port;
   builder.AddListeningPort(GRPC_SERVER_ADDRESS, grpc::InsecureServerCredentials());
   builder.RegisterService(this);
-  //std::unique_ptr<Server> server(builder.BuildAndStart());
   server = builder.BuildAndStart();
   ACA_LOG_INFO("Streaming capable GRPC server listening on %s\n",
                GRPC_SERVER_ADDRESS.c_str());

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -83,13 +83,21 @@ Status GoalStateProvisionerImpl::PushNetworkResourceStatesStream(
   return Status::OK;
 }
 
+Status GoalStateProvisionerImpl::ShutDownServer()
+{
+  ACA_LOG_INFO("Shutdown server");
+  server->Shutdown();
+  return Status::OK;
+}
+
 void GoalStateProvisionerImpl::RunServer()
 {
   ServerBuilder builder;
   string GRPC_SERVER_ADDRESS = "0.0.0.0:" + g_grpc_server_port;
   builder.AddListeningPort(GRPC_SERVER_ADDRESS, grpc::InsecureServerCredentials());
   builder.RegisterService(this);
-  std::unique_ptr<Server> server(builder.BuildAndStart());
+  //std::unique_ptr<Server> server(builder.BuildAndStart());
+  server = builder.BuildAndStart();
   ACA_LOG_INFO("Streaming capable GRPC server listening on %s\n",
                GRPC_SERVER_ADDRESS.c_str());
   server->Wait();


### PR DESCRIPTION
#139 
We used valgrind to find a memory leak and partially fixed it. Get the following result：
==9168== LEAK SUMMARY:
==9168==    definitely lost: 0 bytes in 0 blocks
==9168==    indirectly lost: 0 bytes in 0 blocks
==9168==      possibly lost: 1,503 bytes in 6 blocks
==9168==    still reachable: 71,253 bytes in 175 blocks
==9168==         suppressed: 0 bytes in 0 blocks
==9168==
==9168== For counts of detected and suppressed errors, rerun with: -v
==9168== ERROR SUMMARY: 6 errors from 6 contexts (suppressed: 0 from   0)
