### PR TITLE
[Feature] Adding support for port delete, also include L2/L3 neighbor delete

### DIFF
--- a/include/aca_ovs_l2_programmer.h
+++ b/include/aca_ovs_l2_programmer.h
@@ -31,13 +31,19 @@ class ACA_OVS_L2_Programmer {
 
   int setup_ovs_bridges_if_need();
 
-  int configure_port(const std::string vpc_id, const std::string port_name,
-                     const std::string virtual_ip, uint tunnel_id, ulong &culminative_time);
+  int create_port(const std::string vpc_id, const std::string port_name,
+                  const std::string virtual_ip, uint tunnel_id, ulong &culminative_time);
 
-  int create_update_neighbor_port(const std::string vpc_id,
-                                  alcor::schema::NetworkType network_type,
-                                  const std::string remote_host_ip,
-                                  uint tunnel_id, ulong &culminative_time);
+  int delete_port(const std::string vpc_id, const std::string port_name,
+                  uint tunnel_id, ulong &culminative_time);
+
+  int create_or_update_neighbor_port(const std::string neighbor_id, const std::string vpc_id,
+                                     alcor::schema::NetworkType network_type,
+                                     const std::string remote_host_ip,
+                                     uint tunnel_id, ulong &culminative_time);
+
+  int delete_neighbor_port(const std::string neighbor_id, const std::string vpc_id,
+                           const std::string outport_name, ulong &culminative_time);
 
   void execute_ovsdb_command(const std::string cmd_string,
                              ulong &culminative_time, int &overall_rc);

--- a/include/aca_ovs_l2_programmer.h
+++ b/include/aca_ovs_l2_programmer.h
@@ -37,13 +37,13 @@ class ACA_OVS_L2_Programmer {
   int delete_port(const std::string vpc_id, const std::string port_name,
                   uint tunnel_id, ulong &culminative_time);
 
-  int create_or_update_neighbor_port(const std::string neighbor_id, const std::string vpc_id,
-                                     alcor::schema::NetworkType network_type,
-                                     const std::string remote_host_ip,
-                                     uint tunnel_id, ulong &culminative_time);
+  int create_or_update_l2_neighbor(const std::string neighbor_id, const std::string vpc_id,
+                                   alcor::schema::NetworkType network_type,
+                                   const std::string remote_host_ip,
+                                   uint tunnel_id, ulong &culminative_time);
 
-  int delete_neighbor_port(const std::string neighbor_id, const std::string vpc_id,
-                           const std::string outport_name, ulong &culminative_time);
+  int delete_l2_neighbor(const std::string neighbor_id, const std::string vpc_id,
+                         const std::string outport_name, ulong &culminative_time);
 
   void execute_ovsdb_command(const std::string cmd_string,
                              ulong &culminative_time, int &overall_rc);

--- a/include/aca_ovs_l3_programmer.h
+++ b/include/aca_ovs_l3_programmer.h
@@ -68,13 +68,13 @@ class ACA_OVS_L3_Programmer {
   int delete_router(RouterConfiguration &current_RouterConfiguration,
                     ulong &culminative_time_dataplane_programming_time);
 
-  int create_or_update_neighbor_l3(const string neighbor_id, const string vpc_id,
+  int create_or_update_l3_neighbor(const string neighbor_id, const string vpc_id,
                                    const string subnet_id, const string virtual_ip,
                                    const string virtual_mac,
                                    const string remote_host_ip, uint tunnel_id,
                                    ulong &culminative_time_dataplane_programming_time);
 
-  int delete_neighbor_l3(const string neighbor_id, const string subnet_id,
+  int delete_l3_neighbor(const string neighbor_id, const string subnet_id,
                          const string virtual_ip, ulong &culminative_time);
 
   // compiler will flag the error when below is called.

--- a/include/aca_ovs_l3_programmer.h
+++ b/include/aca_ovs_l3_programmer.h
@@ -84,6 +84,7 @@ class ACA_OVS_L3_Programmer {
 
   string _host_dvr_mac;
 
+  // unordered_map <router IDs, unordered_map <subnet IDs, list of subnet routing tables>>
   unordered_map<string, unordered_map<string, subnet_routing_table_entry> > _routers_table;
 
   // mutex for reading and writing to routers_table

--- a/include/aca_ovs_l3_programmer.h
+++ b/include/aca_ovs_l3_programmer.h
@@ -47,8 +47,10 @@ struct subnet_routing_table_entry {
   string gateway_ip;
   string gateway_mac;
   // list of neighbor ports within the subnet
+  // hashtable <key: neighbor ID, value: neighbor_port_table_entry>
   unordered_map<string, neighbor_port_table_entry> neighbor_ports;
   // list of routing rules for this subnet
+  // hashtable <key: routing rule ID, value: routing_rule_entry>
   unordered_map<string, routing_rule_entry> routing_rules;
 };
 
@@ -87,7 +89,7 @@ class ACA_OVS_L3_Programmer {
 
   string _host_dvr_mac;
 
-  // unordered_map <router IDs, unordered_map <subnet IDs, list of subnet routing tables>>
+  // hashtable <key: router IDs, value: hashtable <key: subnet IDs, value: subnet_routing_table_entry> >
   unordered_map<string, unordered_map<string, subnet_routing_table_entry> > _routers_table;
 
   // mutex for reading and writing to routers_table

--- a/include/aca_ovs_l3_programmer.h
+++ b/include/aca_ovs_l3_programmer.h
@@ -23,7 +23,7 @@ using namespace std;
 using namespace alcor::schema;
 
 // port id is stored as the key to ports table
-struct port_table_entry {
+struct neighbor_port_table_entry {
   string virtual_ip;
   string virtual_mac;
   string host_ip;
@@ -46,8 +46,8 @@ struct subnet_routing_table_entry {
   uint tunnel_id;
   string gateway_ip;
   string gateway_mac;
-  // list of ports within the subnet
-  unordered_map<string, port_table_entry> ports;
+  // list of neighbor ports within the subnet
+  unordered_map<string, neighbor_port_table_entry> neighbor_ports;
   // list of routing rules for this subnet
   unordered_map<string, routing_rule_entry> routing_rules;
 };

--- a/include/aca_ovs_l3_programmer.h
+++ b/include/aca_ovs_l3_programmer.h
@@ -66,13 +66,14 @@ class ACA_OVS_L3_Programmer {
   int delete_router(RouterConfiguration &current_RouterConfiguration,
                     ulong &culminative_time_dataplane_programming_time);
 
-  // TODO: also need to add the corresponding update and delete operations
-  // at least the prototype but ideally the full implementation
-  int create_or_update_neighbor_l3(const string vpc_id, const string subnet_id,
-                                   alcor::schema::NetworkType network_type,
-                                   const string virtual_ip, const string virtual_mac,
+  int create_or_update_neighbor_l3(const string neighbor_id, const string vpc_id,
+                                   const string subnet_id, const string virtual_ip,
+                                   const string virtual_mac,
                                    const string remote_host_ip, uint tunnel_id,
                                    ulong &culminative_time_dataplane_programming_time);
+
+  int delete_neighbor_l3(const string neighbor_id, const string subnet_id,
+                         const string virtual_ip, ulong &culminative_time);
 
   // compiler will flag the error when below is called.
   ACA_OVS_L3_Programmer(ACA_OVS_L3_Programmer const &) = delete;

--- a/include/aca_ovs_l3_programmer.h
+++ b/include/aca_ovs_l3_programmer.h
@@ -59,6 +59,8 @@ class ACA_OVS_L3_Programmer {
   public:
   static ACA_OVS_L3_Programmer &get_instance();
 
+  void clear_all_data();
+
   int create_or_update_router(RouterConfiguration &current_RouterConfiguration,
                               GoalState &parsed_struct,
                               ulong &culminative_time_dataplane_programming_time);

--- a/src/comm/aca_comm_mgr.cpp
+++ b/src/comm/aca_comm_mgr.cpp
@@ -187,7 +187,7 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
     auto current_auxiliary_gateway = current_VpcConfiguration.auxiliary_gateway();
 
     fprintf(stdout, "current_auxiliary_gateway.auxgateway_type(): %d\n",
-            current_auxiliary_gateway.auxgateway_type());
+            current_auxiliary_gateway.aux_gateway_type());
 
     fprintf(stdout, "current_auxiliary_gateway.id(): %s\n",
             current_auxiliary_gateway.id().c_str());

--- a/src/comm/aca_comm_mgr.cpp
+++ b/src/comm/aca_comm_mgr.cpp
@@ -38,7 +38,8 @@ Aca_Comm_Manager &Aca_Comm_Manager::get_instance()
   return instance;
 }
 
-int Aca_Comm_Manager::deserialize(const unsigned char *mq_buffer, size_t buffer_length, GoalState &parsed_struct)
+int Aca_Comm_Manager::deserialize(const unsigned char *mq_buffer,
+                                  size_t buffer_length, GoalState &parsed_struct)
 {
   int rc;
 
@@ -157,11 +158,17 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
     fprintf(stdout, "current_VpcConfiguration.revision_number(): %d\n",
             current_VpcConfiguration.revision_number());
 
-    fprintf(stdout, "current_VpcConfiguration.project_id(): %s\n",
-            current_VpcConfiguration.project_id().c_str());
+    fprintf(stdout, "current_VpcConfiguration.request_id(): %s\n",
+            current_VpcConfiguration.request_id().c_str());
 
     fprintf(stdout, "current_VpcConfiguration.id(): %s\n",
             current_VpcConfiguration.id().c_str());
+
+    fprintf(stdout, "current_VpcConfiguration.update_type(): %d\n",
+            current_VpcConfiguration.update_type());
+
+    fprintf(stdout, "current_VpcConfiguration.project_id(): %s\n",
+            current_VpcConfiguration.project_id().c_str());
 
     fprintf(stdout, "current_VpcConfiguration.name(): %s \n",
             current_VpcConfiguration.name().c_str());
@@ -169,7 +176,7 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
     fprintf(stdout, "current_VpcConfiguration.cidr(): %s \n",
             current_VpcConfiguration.cidr().c_str());
 
-    fprintf(stdout, "current_VpcConfiguration.tunnel_id(): %ld \n",
+    fprintf(stdout, "current_VpcConfiguration.tunnel_id(): %u \n",
             current_VpcConfiguration.tunnel_id());
 
     for (int j = 0; j < current_VpcConfiguration.subnet_ids_size(); j++) {
@@ -177,17 +184,7 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
               current_VpcConfiguration.subnet_ids(j).id().c_str());
     }
 
-    for (int k = 0; k < current_VpcConfiguration.routes_size(); k++) {
-      fprintf(stdout,
-              "current_VpcConfiguration.routes(%d).destination(): "
-              "%s \n",
-              k, current_VpcConfiguration.routes(k).destination().c_str());
-
-      fprintf(stdout,
-              "current_VpcConfiguration.routes(%d).next_hop(): "
-              "%s \n",
-              k, current_VpcConfiguration.routes(k).next_hop().c_str());
-    }
+    auto current_auxiliary_gateway = current_VpcConfiguration.auxiliary_gateway();
 
     printf("\n");
   }
@@ -386,8 +383,8 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
     fprintf(stdout, "current_SecurityGroupConfiguration.id(): %s\n",
             current_SecurityGroupConfiguration.id().c_str());
 
-    fprintf(stdout, "current_SecurityGroupConfiguration.message_type(): %d\n",
-            current_SecurityGroupConfiguration.message_type());
+    fprintf(stdout, "current_SecurityGroupConfiguration.update_type(): %d\n",
+            current_SecurityGroupConfiguration.update_type());
 
     fprintf(stdout, "current_SecurityGroupConfiguration.project_id(): %s\n",
             current_SecurityGroupConfiguration.project_id().c_str());

--- a/src/comm/aca_comm_mgr.cpp
+++ b/src/comm/aca_comm_mgr.cpp
@@ -186,6 +186,25 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
 
     auto current_auxiliary_gateway = current_VpcConfiguration.auxiliary_gateway();
 
+    fprintf(stdout, "current_auxiliary_gateway.auxgateway_type(): %d\n",
+            current_auxiliary_gateway.auxgateway_type());
+
+    fprintf(stdout, "current_auxiliary_gateway.id(): %s\n",
+            current_auxiliary_gateway.id().c_str());
+
+    for (int k = 0; k < current_auxiliary_gateway.destinations_size(); k++) {
+      fprintf(stdout, "current_auxiliary_gateway.destinations(%d).ip_address(): %s \n",
+              k, current_auxiliary_gateway.destinations(k).ip_address().c_str());
+
+      fprintf(stdout, "current_auxiliary_gateway.destinations(%d).mac_address(): %s \n",
+              k, current_auxiliary_gateway.destinations(k).mac_address().c_str());
+    }
+
+    if (current_auxiliary_gateway.has_zeta_info()) {
+      fprintf(stdout, "current_auxiliary_gateway.zeta_info().port_inband_operation: %d\n",
+              current_auxiliary_gateway.zeta_info().port_inband_operation());
+    }
+
     printf("\n");
   }
 
@@ -277,6 +296,12 @@ void Aca_Comm_Manager::print_goal_state(GoalState parsed_struct)
 
     fprintf(stdout, "current_PortConfiguration.name(): %s \n",
             current_PortConfiguration.name().c_str());
+
+    fprintf(stdout, "current_PortConfiguration.device_id(): %s\n",
+            current_PortConfiguration.device_id().c_str());
+
+    fprintf(stdout, "current_PortConfiguration.device_owner(): %s \n",
+            current_PortConfiguration.device_owner().c_str());
 
     fprintf(stdout, "current_PortConfiguration.mac_address(): %s \n",
             current_PortConfiguration.mac_address().c_str());

--- a/src/dp_abstraction/aca_dataplane_ovs.cpp
+++ b/src/dp_abstraction/aca_dataplane_ovs.cpp
@@ -401,12 +401,15 @@ int ACA_Dataplane_OVS::update_neighbor_state_workitem(NeighborState current_Neig
                   (current_NeighborState.operation_type() == OperationType::UPDATE) ||
                   (current_NeighborState.operation_type() == OperationType::INFO)) {
                 overall_rc = ACA_OVS_L3_Programmer::get_instance().create_or_update_neighbor_l3(
+                        current_NeighborConfiguration.id(),
                         current_NeighborConfiguration.vpc_id(),
-                        current_fixed_ip.subnet_id(), found_network_type,
-                        virtual_ip_address, virtual_mac_address, host_ip_address,
-                        found_tunnel_id, culminative_dataplane_programming_time);
+                        current_fixed_ip.subnet_id(), virtual_ip_address,
+                        virtual_mac_address, host_ip_address, found_tunnel_id,
+                        culminative_dataplane_programming_time);
               } else if (current_NeighborState.operation_type() == OperationType::DELETE) {
-                // TBD: DELETE L3 neighbor
+                overall_rc = ACA_OVS_L3_Programmer::get_instance().delete_neighbor_l3(
+                        current_NeighborConfiguration.id(), current_fixed_ip.subnet_id(),
+                        virtual_ip_address, culminative_dataplane_programming_time);
               } else {
                 ACA_LOG_ERROR("Invalid neighbor state operation type %d\n",
                               current_NeighborState.operation_type());

--- a/src/dp_abstraction/aca_dataplane_ovs.cpp
+++ b/src/dp_abstraction/aca_dataplane_ovs.cpp
@@ -30,10 +30,9 @@ using namespace aca_ovs_l3_programmer;
 
 namespace aca_dataplane_ovs
 {
-static bool
-aca_lookup_subnet_info(GoalState &parsed_struct, const string targeted_subnet_id,
-                       NetworkType found_network_type, uint found_tunnel_id,
-                       string found_cidr, string found_prefix_len)
+static bool aca_lookup_subnet_info(GoalState &parsed_struct, const string targeted_subnet_id,
+                                   NetworkType &found_network_type,
+                                   uint &found_tunnel_id, string &found_prefix_len)
 {
   // TODO: cache the subnet information to a dictionary to provide
   // a faster look up for the next run, only use the below loop for
@@ -54,7 +53,7 @@ aca_lookup_subnet_info(GoalState &parsed_struct, const string targeted_subnet_id
           throw std::invalid_argument("found_tunnel_id is invalid");
         }
 
-        found_cidr = current_SubnetConfiguration.cidr();
+        string found_cidr = current_SubnetConfiguration.cidr();
         size_t slash_pos = found_cidr.find('/');
         if (slash_pos == string::npos) {
           throw std::invalid_argument("'/' not found in cidr");
@@ -130,9 +129,8 @@ int ACA_Dataplane_OVS::update_port_state_workitem(const PortState current_PortSt
   int overall_rc;
   string generated_port_name;
   struct sockaddr_in sa;
-  uint found_tunnel_id = 0;
-  NetworkType found_network_type = NetworkType::VXLAN;
-  string found_cidr;
+  uint found_tunnel_id;
+  NetworkType found_network_type;
   string found_prefix_len;
   string virtual_ip_address;
   string virtual_mac_address;
@@ -163,7 +161,7 @@ int ACA_Dataplane_OVS::update_port_state_workitem(const PortState current_PortSt
 
     if (!aca_lookup_subnet_info(
                 parsed_struct, current_PortConfiguration.fixed_ips(0).subnet_id(),
-                found_network_type, found_tunnel_id, found_cidr, found_prefix_len)) {
+                found_network_type, found_tunnel_id, found_prefix_len)) {
       ACA_LOG_ERROR("Not able to find the info for port with subnet ID: %s.\n",
                     current_PortConfiguration.fixed_ips(0).subnet_id().c_str());
       overall_rc = -EXIT_FAILURE;

--- a/src/dp_abstraction/aca_dataplane_ovs.cpp
+++ b/src/dp_abstraction/aca_dataplane_ovs.cpp
@@ -373,7 +373,7 @@ int ACA_Dataplane_OVS::update_neighbor_state_workitem(NeighborState current_Neig
             if ((current_NeighborState.operation_type() == OperationType::CREATE) ||
                 (current_NeighborState.operation_type() == OperationType::UPDATE) ||
                 (current_NeighborState.operation_type() == OperationType::INFO)) {
-              overall_rc = ACA_OVS_L2_Programmer::get_instance().create_or_update_neighbor_port(
+              overall_rc = ACA_OVS_L2_Programmer::get_instance().create_or_update_l2_neighbor(
                       current_NeighborConfiguration.id(),
                       current_NeighborConfiguration.vpc_id(), found_network_type, host_ip_address,
                       found_tunnel_id, culminative_dataplane_programming_time);
@@ -384,7 +384,7 @@ int ACA_Dataplane_OVS::update_neighbor_state_workitem(NeighborState current_Neig
               string outport_name =
                       aca_get_outport_name(found_network_type, host_ip_address);
 
-              overall_rc = ACA_OVS_L2_Programmer::get_instance().delete_neighbor_port(
+              overall_rc = ACA_OVS_L2_Programmer::get_instance().delete_l2_neighbor(
                       current_NeighborConfiguration.id(),
                       current_NeighborConfiguration.vpc_id(), outport_name,
                       culminative_dataplane_programming_time);
@@ -400,14 +400,14 @@ int ACA_Dataplane_OVS::update_neighbor_state_workitem(NeighborState current_Neig
               if ((current_NeighborState.operation_type() == OperationType::CREATE) ||
                   (current_NeighborState.operation_type() == OperationType::UPDATE) ||
                   (current_NeighborState.operation_type() == OperationType::INFO)) {
-                overall_rc = ACA_OVS_L3_Programmer::get_instance().create_or_update_neighbor_l3(
+                overall_rc = ACA_OVS_L3_Programmer::get_instance().create_or_update_l3_neighbor(
                         current_NeighborConfiguration.id(),
                         current_NeighborConfiguration.vpc_id(),
                         current_fixed_ip.subnet_id(), virtual_ip_address,
                         virtual_mac_address, host_ip_address, found_tunnel_id,
                         culminative_dataplane_programming_time);
               } else if (current_NeighborState.operation_type() == OperationType::DELETE) {
-                overall_rc = ACA_OVS_L3_Programmer::get_instance().delete_neighbor_l3(
+                overall_rc = ACA_OVS_L3_Programmer::get_instance().delete_l3_neighbor(
                         current_NeighborConfiguration.id(), current_fixed_ip.subnet_id(),
                         virtual_ip_address, culminative_dataplane_programming_time);
               } else {

--- a/src/dp_abstraction/aca_dataplane_ovs.cpp
+++ b/src/dp_abstraction/aca_dataplane_ovs.cpp
@@ -104,26 +104,67 @@ int ACA_Dataplane_OVS::update_port_state_workitem(const PortState current_PortSt
 
   PortConfiguration current_PortConfiguration = current_PortState.configuration();
 
-  // TODO: need to design the usage of current_PortConfiguration.revision_number()
-  assert(current_PortConfiguration.revision_number() > 0);
+  try {
+    // TODO: need to design the usage of current_PortConfiguration.revision_number()
+    assert(current_PortConfiguration.revision_number() > 0);
 
-  // TODO: handle current_PortConfiguration.admin_state_up = false
-  // need to look into the meaning of that during nova integration
-  assert(current_PortConfiguration.admin_state_up() == true);
-
-  switch (current_PortState.operation_type()) {
-  case OperationType::CREATE:
-
-    assert(current_PortConfiguration.message_type() == MessageType::FULL);
+    // TODO: handle current_PortConfiguration.admin_state_up = false
+    // need to look into the meaning of that during nova integration
+    assert(current_PortConfiguration.admin_state_up() == true);
 
     assert(!current_PortConfiguration.id().empty());
 
     generated_port_name = aca_get_port_name(current_PortConfiguration.id());
 
-    try {
-      if (!aca_validate_fixed_ips_size(current_PortConfiguration.fixed_ips_size())) {
-        throw std::invalid_argument("PortConfiguration.fixed_ips_size is less than zero");
+    if (!aca_validate_fixed_ips_size(current_PortConfiguration.fixed_ips_size())) {
+      throw std::invalid_argument("PortConfiguration.fixed_ips_size is less than zero");
+    }
+
+    // TODO: cache the subnet information to a dictionary to provide
+    // a faster look up for the next run, only use the below loop for
+    // cache miss.
+    // Look up the subnet configuration to query for tunnel_id
+    for (int j = 0; j < parsed_struct.subnet_states_size(); j++) {
+      SubnetConfiguration current_SubnetConfiguration =
+              parsed_struct.subnet_states(j).configuration();
+
+      ACA_LOG_DEBUG("current_SubnetConfiguration subnet ID: %s.\n",
+                    current_SubnetConfiguration.id().c_str());
+
+      if (parsed_struct.subnet_states(j).operation_type() == OperationType::INFO) {
+        if (current_SubnetConfiguration.id() ==
+            current_PortConfiguration.fixed_ips(0).subnet_id()) {
+          found_network_type = current_SubnetConfiguration.network_type();
+          found_tunnel_id = current_SubnetConfiguration.tunnel_id();
+          if (!aca_validate_tunnel_id(found_tunnel_id, found_network_type)) {
+            throw std::invalid_argument("found_tunnel_id is invalid");
+          }
+
+          found_cidr = current_SubnetConfiguration.cidr();
+          slash_pos = found_cidr.find('/');
+          if (slash_pos == string::npos) {
+            throw std::invalid_argument("'/' not found in cidr");
+          }
+
+          // substr can throw out_of_range and bad_alloc exceptions
+          found_prefix_len = found_cidr.substr(slash_pos + 1);
+
+          subnet_info_found = true;
+          break;
+        }
       }
+    }
+
+    if (!subnet_info_found) {
+      ACA_LOG_ERROR("Not able to find the info for port with subnet ID: %s.\n",
+                    current_PortConfiguration.fixed_ips(0).subnet_id().c_str());
+      overall_rc = -EXIT_FAILURE;
+      goto Done;
+    }
+
+    switch (current_PortState.operation_type()) {
+    case OperationType::CREATE:
+      assert(current_PortConfiguration.message_type() == MessageType::FULL);
 
       virtual_ip_address = current_PortConfiguration.fixed_ips(0).ip_address();
 
@@ -135,183 +176,73 @@ int ACA_Dataplane_OVS::update_port_state_workitem(const PortState current_PortSt
       virtual_mac_address = current_PortConfiguration.mac_address();
       if (!aca_validate_mac_address(virtual_mac_address.c_str())) {
         throw std::invalid_argument("virtual_mac_address is invalid");
-      }
-
-      // TODO: cache the subnet information to a dictionary to provide
-      // a faster look up for the next run, only use the below loop for
-      // cache miss.
-      // Look up the subnet configuration to query for tunnel_id
-      for (int j = 0; j < parsed_struct.subnet_states_size(); j++) {
-        SubnetConfiguration current_SubnetConfiguration =
-                parsed_struct.subnet_states(j).configuration();
-
-        ACA_LOG_DEBUG("current_SubnetConfiguration subnet ID: %s.\n",
-                      current_SubnetConfiguration.id().c_str());
-
-        if (parsed_struct.subnet_states(j).operation_type() == OperationType::INFO) {
-          if (current_SubnetConfiguration.id() ==
-              current_PortConfiguration.fixed_ips(0).subnet_id()) {
-            found_network_type = current_SubnetConfiguration.network_type();
-            found_tunnel_id = current_SubnetConfiguration.tunnel_id();
-            if (!aca_validate_tunnel_id(found_tunnel_id, found_network_type)) {
-              throw std::invalid_argument("found_tunnel_id is invalid");
-            }
-
-            found_cidr = current_SubnetConfiguration.cidr();
-            slash_pos = found_cidr.find('/');
-            if (slash_pos == string::npos) {
-              throw std::invalid_argument("'/' not found in cidr");
-            }
-
-            // substr can throw out_of_range and bad_alloc exceptions
-            found_prefix_len = found_cidr.substr(slash_pos + 1);
-
-            subnet_info_found = true;
-            break;
-          }
-        }
-      }
-
-      if (!subnet_info_found) {
-        ACA_LOG_ERROR("Not able to find the info for port with subnet ID: %s.\n",
-                      current_PortConfiguration.fixed_ips(0).subnet_id().c_str());
-        overall_rc = -EXIT_FAILURE;
-      } else {
-        overall_rc = EXIT_SUCCESS;
       }
 
       port_cidr = virtual_ip_address + "/" + found_prefix_len;
 
-      if (overall_rc == EXIT_SUCCESS) {
-        ACA_LOG_DEBUG("Port Operation: %s: port_id: %s, project_id:%s, vpc_id:%s, network_type:%d, "
-                      "virtual_ip_address:%s, virtual_mac_address:%s, generated_port_name: %s, port_cidr: %s, tunnel_id: %d\n",
-                      aca_get_operation_string(current_PortState.operation_type()),
-                      current_PortConfiguration.id().c_str(),
-                      current_PortConfiguration.project_id().c_str(),
-                      current_PortConfiguration.vpc_id().c_str(), found_network_type,
-                      virtual_ip_address.c_str(), virtual_mac_address.c_str(),
-                      generated_port_name.c_str(), port_cidr.c_str(), found_tunnel_id);
+      ACA_LOG_DEBUG("Port Operation: %s: port_id: %s, project_id:%s, vpc_id:%s, network_type:%d, "
+                    "virtual_ip_address:%s, virtual_mac_address:%s, generated_port_name: %s, port_cidr: %s, tunnel_id: %d\n",
+                    aca_get_operation_string(current_PortState.operation_type()),
+                    current_PortConfiguration.id().c_str(),
+                    current_PortConfiguration.project_id().c_str(),
+                    current_PortConfiguration.vpc_id().c_str(), found_network_type,
+                    virtual_ip_address.c_str(), virtual_mac_address.c_str(),
+                    generated_port_name.c_str(), port_cidr.c_str(), found_tunnel_id);
 
-        overall_rc = ACA_OVS_L2_Programmer::get_instance().configure_port(
-                current_PortConfiguration.vpc_id(), generated_port_name, port_cidr,
-                found_tunnel_id, culminative_dataplane_programming_time);
+      overall_rc = ACA_OVS_L2_Programmer::get_instance().create_port(
+              current_PortConfiguration.vpc_id(), generated_port_name, port_cidr,
+              found_tunnel_id, culminative_dataplane_programming_time);
+
+      break;
+
+    case OperationType::UPDATE:
+      // only delete scenario is supported now
+      // VM was created with port specified, then delete the VM
+      // ACA will receive update with no device_id and device_owner
+      if (!current_PortConfiguration.device_id().empty() ||
+          !current_PortConfiguration.device_owner().empty()) {
+        throw std::invalid_argument("Port Operation: update but device_id or device_owner not empty");
       }
+      [[fallthrough]];
+    case OperationType::DELETE:
+      // another delete scenario is supported here
+      // VM was created with without port specified, then delete the VM
+      // ACA will receive port operation delete
+      ACA_LOG_DEBUG("Port Operation: %s: port_id: %s, project_id:%s, vpc_id:%s, network_type:%d, "
+                    "generated_port_name: %s, tunnel_id: %d\n",
+                    aca_get_operation_string(current_PortState.operation_type()),
+                    current_PortConfiguration.id().c_str(),
+                    current_PortConfiguration.project_id().c_str(),
+                    current_PortConfiguration.vpc_id().c_str(), found_network_type,
+                    generated_port_name.c_str(), found_tunnel_id);
 
-    } catch (const std::invalid_argument &e) {
-      ACA_LOG_ERROR("Invalid argument exception caught while parsing port configuration, message: %s.\n",
-                    e.what());
-      overall_rc = -EINVAL;
-    } catch (const std::exception &e) {
-      ACA_LOG_ERROR("Exception caught while parsing port configuration, message: %s.\n",
-                    e.what());
-      overall_rc = -EFAULT;
-    } catch (...) {
-      ACA_LOG_CRIT("%s", "Unknown exception caught while parsing port configuration.\n");
-      overall_rc = -EFAULT;
+      overall_rc = ACA_OVS_L2_Programmer::get_instance().delete_port(
+              current_PortConfiguration.vpc_id(), generated_port_name,
+              found_tunnel_id, culminative_dataplane_programming_time);
+
+      break;
+
+    default:
+      ACA_LOG_ERROR("Invalid port state operation type %d\n",
+                    current_PortState.operation_type());
+      overall_rc = -EXIT_FAILURE;
+      break;
     }
 
-    break;
-
-  case OperationType::NEIGHBOR_CREATE_UPDATE:
-    /* deprecating */
-    assert(current_PortConfiguration.message_type() == MessageType::DELTA);
-
-    try {
-      if (current_PortConfiguration.fixed_ips_size() <= 0) {
-        ACA_LOG_ERROR("PortConfiguration.fixed_ips_size: %d.\n",
-                      current_PortConfiguration.fixed_ips_size());
-        throw std::invalid_argument("PortConfiguration.fixed_ips_size is less than zero");
-      }
-      virtual_ip_address = current_PortConfiguration.fixed_ips(0).ip_address();
-
-      // inet_pton returns 1 for success 0 for failure
-      if (inet_pton(AF_INET, virtual_ip_address.c_str(), &(sa.sin_addr)) != 1) {
-        throw std::invalid_argument("Virtual ip address is not in the expect format");
-      }
-
-      virtual_mac_address = current_PortConfiguration.mac_address();
-
-      if (!aca_validate_mac_address(virtual_mac_address.c_str())) {
-        throw std::invalid_argument("virtual_mac_address is invalid");
-      }
-
-      host_ip_address = current_PortConfiguration.host_info().ip_address();
-
-      // inet_pton returns 1 for success 0 for failure
-      if (inet_pton(AF_INET, host_ip_address.c_str(), &(sa.sin_addr)) != 1) {
-        throw std::invalid_argument("Neighbor host ip address is not in the expect format");
-      }
-
-      // TODO: cache the subnet information to a dictionary to provide
-      // a faster look up for the next run, only use the below loop for
-      // cache miss.
-      // Look up the subnet configuration to query for tunnel_id
-      for (int j = 0; j < parsed_struct.subnet_states_size(); j++) {
-        SubnetConfiguration current_SubnetConfiguration =
-                parsed_struct.subnet_states(j).configuration();
-
-        ACA_LOG_DEBUG("current_SubnetConfiguration subnet ID: %s.\n",
-                      current_SubnetConfiguration.id().c_str());
-
-        if (parsed_struct.subnet_states(j).operation_type() == OperationType::INFO) {
-          if (current_SubnetConfiguration.id() ==
-              current_PortConfiguration.fixed_ips(0).subnet_id()) {
-            found_network_type = current_SubnetConfiguration.network_type();
-            found_tunnel_id = current_SubnetConfiguration.tunnel_id();
-            if (!aca_validate_tunnel_id(found_tunnel_id, found_network_type)) {
-              throw std::invalid_argument("found_tunnel_id is invalid");
-            }
-
-            subnet_info_found = true;
-            break;
-          }
-        }
-      }
-
-      if (!subnet_info_found) {
-        ACA_LOG_ERROR("Not able to find the info for port with subnet ID: %s.\n",
-                      current_PortConfiguration.fixed_ips(0).subnet_id().c_str());
-        overall_rc = -EXIT_FAILURE;
-      } else {
-        overall_rc = EXIT_SUCCESS;
-      }
-
-      if (overall_rc == EXIT_SUCCESS) {
-        ACA_LOG_DEBUG("Port Operation:%s: project_id:%s, vpc_id:%s, network_type:%d, virtual_ip_address:%s, "
-                      "virtual_mac_address:%s, neighbor_host_ip_address:%s, tunnel_id:%d\n ",
-                      aca_get_operation_string(current_PortState.operation_type()),
-                      current_PortConfiguration.project_id().c_str(),
-                      current_PortConfiguration.vpc_id().c_str(), found_network_type,
-                      virtual_ip_address.c_str(), virtual_mac_address.c_str(),
-                      host_ip_address.c_str(), found_tunnel_id);
-
-        overall_rc = ACA_OVS_L2_Programmer::get_instance().create_update_neighbor_port(
-                current_PortConfiguration.vpc_id(),
-                current_PortConfiguration.network_type(), host_ip_address,
-                found_tunnel_id, culminative_dataplane_programming_time);
-      }
-
-    } catch (const std::invalid_argument &e) {
-      ACA_LOG_ERROR("Invalid argument exception caught while parsing port configuration, message: %s.\n",
-                    e.what());
-      overall_rc = -EINVAL;
-    } catch (const std::exception &e) {
-      ACA_LOG_ERROR("Exception caught while parsing port configuration, message: %s.\n",
-                    e.what());
-      overall_rc = -EFAULT;
-    } catch (...) {
-      ACA_LOG_CRIT("%s", "Unknown exception caught while parsing port configuration.\n");
-      overall_rc = -EFAULT;
-    }
-
-    break;
-
-  default:
-    ACA_LOG_ERROR("Invalid port state operation type %d\n",
-                  current_PortState.operation_type());
-    overall_rc = -EXIT_FAILURE;
-    break;
+  } catch (const std::invalid_argument &e) {
+    ACA_LOG_ERROR("Invalid argument exception caught while parsing port configuration, message: %s.\n",
+                  e.what());
+    overall_rc = -EINVAL;
+  } catch (const std::exception &e) {
+    ACA_LOG_ERROR("Exception caught while parsing port configuration, message: %s.\n",
+                  e.what());
+    overall_rc = -EFAULT;
+  } catch (...) {
+    ACA_LOG_CRIT("%s", "Unknown exception caught while parsing port configuration.\n");
+    overall_rc = -EFAULT;
   }
+
+Done:
 
   auto operation_end = chrono::steady_clock::now();
 
@@ -355,142 +286,154 @@ int ACA_Dataplane_OVS::update_neighbor_state_workitem(NeighborState current_Neig
   NeighborConfiguration current_NeighborConfiguration =
           current_NeighborState.configuration();
 
-  // TODO: need to design the usage of current_NeighborConfiguration.revision_number()
-  assert(current_NeighborConfiguration.revision_number() > 0);
+  try {
+    if (!aca_validate_fixed_ips_size(current_NeighborConfiguration.fixed_ips_size())) {
+      throw std::invalid_argument("NeighborConfiguration.fixed_ips_size is less than zero");
+    }
 
-  switch (current_NeighborState.operation_type()) {
-  case OperationType::CREATE:
-    [[fallthrough]];
-  case OperationType::UPDATE:
-    [[fallthrough]];
-  case OperationType::INFO:
+    // TODO: need to design the usage of current_NeighborConfiguration.revision_number()
+    assert(current_NeighborConfiguration.revision_number() > 0);
 
-    try {
-      if (!aca_validate_fixed_ips_size(current_NeighborConfiguration.fixed_ips_size())) {
-        throw std::invalid_argument("NeighborConfiguration.fixed_ips_size is less than zero");
-      }
+    for (int ip_index = 0;
+         ip_index < current_NeighborConfiguration.fixed_ips_size(); ip_index++) {
+      auto current_fixed_ip = current_NeighborConfiguration.fixed_ips(ip_index);
 
-      for (int ip_index = 0;
-           ip_index < current_NeighborConfiguration.fixed_ips_size(); ip_index++) {
-        auto current_fixed_ip = current_NeighborConfiguration.fixed_ips(ip_index);
+      if (current_fixed_ip.neighbor_type() == NeighborType::L2 ||
+          current_fixed_ip.neighbor_type() == NeighborType::L3) {
+        virtual_ip_address = current_fixed_ip.ip_address();
 
-        if (current_fixed_ip.neighbor_type() == NeighborType::L2 ||
-            current_fixed_ip.neighbor_type() == NeighborType::L3) {
-          virtual_ip_address = current_fixed_ip.ip_address();
+        // inet_pton returns 1 for success 0 for failure
+        if (inet_pton(AF_INET, virtual_ip_address.c_str(), &(sa.sin_addr)) != 1) {
+          throw std::invalid_argument("Virtual ip address is not in the expect format");
+        }
 
-          // inet_pton returns 1 for success 0 for failure
-          if (inet_pton(AF_INET, virtual_ip_address.c_str(), &(sa.sin_addr)) != 1) {
-            throw std::invalid_argument("Virtual ip address is not in the expect format");
-          }
+        virtual_mac_address = current_NeighborConfiguration.mac_address();
+        if (!aca_validate_mac_address(virtual_mac_address.c_str())) {
+          throw std::invalid_argument("virtual_mac_address is invalid");
+        }
 
-          virtual_mac_address = current_NeighborConfiguration.mac_address();
-          if (!aca_validate_mac_address(virtual_mac_address.c_str())) {
-            throw std::invalid_argument("virtual_mac_address is invalid");
-          }
+        host_ip_address = current_NeighborConfiguration.host_ip_address();
 
-          host_ip_address = current_NeighborConfiguration.host_ip_address();
+        // inet_pton returns 1 for success 0 for failure
+        if (inet_pton(AF_INET, host_ip_address.c_str(), &(sa.sin_addr)) != 1) {
+          throw std::invalid_argument("Neighbor host ip address is not in the expect format");
+        }
 
-          // inet_pton returns 1 for success 0 for failure
-          if (inet_pton(AF_INET, host_ip_address.c_str(), &(sa.sin_addr)) != 1) {
-            throw std::invalid_argument("Neighbor host ip address is not in the expect format");
-          }
+        // Look up the subnet configuration to query for tunnel_id
+        for (int j = 0; j < parsed_struct.subnet_states_size(); j++) {
+          SubnetConfiguration current_SubnetConfiguration =
+                  parsed_struct.subnet_states(j).configuration();
 
-          // Look up the subnet configuration to query for tunnel_id
-          for (int j = 0; j < parsed_struct.subnet_states_size(); j++) {
-            SubnetConfiguration current_SubnetConfiguration =
-                    parsed_struct.subnet_states(j).configuration();
+          ACA_LOG_DEBUG("current_SubnetConfiguration subnet ID: %s.\n",
+                        current_SubnetConfiguration.id().c_str());
 
-            ACA_LOG_DEBUG("current_SubnetConfiguration subnet ID: %s.\n",
-                          current_SubnetConfiguration.id().c_str());
+          if (parsed_struct.subnet_states(j).operation_type() == OperationType::INFO) {
+            if (current_SubnetConfiguration.id() == current_fixed_ip.subnet_id()) {
+              found_network_type = current_SubnetConfiguration.network_type();
 
-            if (parsed_struct.subnet_states(j).operation_type() == OperationType::INFO) {
-              if (current_SubnetConfiguration.id() == current_fixed_ip.subnet_id()) {
-                found_network_type = current_SubnetConfiguration.network_type();
-
-                found_tunnel_id = current_SubnetConfiguration.tunnel_id();
-                if (!aca_validate_tunnel_id(found_tunnel_id, found_network_type)) {
-                  throw std::invalid_argument("found_tunnel_id is invalid");
-                }
-
-                subnet_info_found = true;
-                break;
+              found_tunnel_id = current_SubnetConfiguration.tunnel_id();
+              if (!aca_validate_tunnel_id(found_tunnel_id, found_network_type)) {
+                throw std::invalid_argument("found_tunnel_id is invalid");
               }
+
+              subnet_info_found = true;
+              break;
             }
           }
+        }
 
-          if (!subnet_info_found) {
-            ACA_LOG_ERROR("Not able to find the info for neighbor ip_index: %d with subnet ID: %s.\n",
-                          ip_index, current_fixed_ip.subnet_id().c_str());
-            overall_rc = -EXIT_FAILURE;
+        if (!subnet_info_found) {
+          ACA_LOG_ERROR("Not able to find the info for neighbor ip_index: %d with subnet ID: %s.\n",
+                        ip_index, current_fixed_ip.subnet_id().c_str());
+          overall_rc = -EXIT_FAILURE;
+        } else {
+          ACA_LOG_DEBUG(
+                  "Neighbor Operation:%s: id: %s, neighbor_type:%s, project_id:%s, vpc_id:%s, network_type:%d, ip_index: %d,"
+                  "virtual_ip_address:%s, virtual_mac_address:%s, neighbor_host_ip_address:%s, tunnel_id:%d\n",
+                  aca_get_operation_string(current_NeighborState.operation_type()),
+                  current_NeighborConfiguration.id().c_str(),
+                  aca_get_neighbor_type_string(current_fixed_ip.neighbor_type()),
+                  current_NeighborConfiguration.project_id().c_str(),
+                  current_NeighborConfiguration.vpc_id().c_str(), found_network_type,
+                  ip_index, virtual_ip_address.c_str(), virtual_mac_address.c_str(),
+                  host_ip_address.c_str(), found_tunnel_id);
+
+          // with Alcor DVR, a cross subnet packet will be routed to the destination subnet.
+          // that means a L3 neighbor will become a L2 neighbor, therefore, call the below
+          // for both L2 and L3 neighbor update
+
+          // only need to update L2 neighbor info if it is not on the same compute host
+          bool is_neighbor_port_on_same_host = aca_is_port_on_same_host(host_ip_address);
+
+          if (is_neighbor_port_on_same_host) {
+            ACA_LOG_DEBUG("neighbor host: %s is on the same compute node, don't need to update L2 neighbor info.\n",
+                          host_ip_address.c_str());
+            overall_rc = EXIT_SUCCESS;
           } else {
-            ACA_LOG_DEBUG(
-                    "Neighbor Operation:%s: neighbor_type:%s, project_id:%s, vpc_id:%s, network_type:%d, ip_index: %d,"
-                    "virtual_ip_address:%s, virtual_mac_address:%s, neighbor_host_ip_address:%s, tunnel_id:%d\n",
-                    aca_get_operation_string(current_NeighborState.operation_type()),
-                    aca_get_neighbor_type_string(current_fixed_ip.neighbor_type()),
-                    current_NeighborConfiguration.project_id().c_str(),
-                    current_NeighborConfiguration.vpc_id().c_str(),
-                    found_network_type, ip_index, virtual_ip_address.c_str(),
-                    virtual_mac_address.c_str(), host_ip_address.c_str(), found_tunnel_id);
-
-            // with Alcor DVR, a cross subnet packet will be routed to the destination subnet.
-            // that means a L3 neighbor will become a L2 neighbor, therefore, call the below
-            // for both L2 and L3 neighbor update
-
-            // only need to update L2 neighbor info if it is not on the same compute host
-            bool is_neighbor_port_on_same_host = aca_is_port_on_same_host(host_ip_address);
-
-            if (is_neighbor_port_on_same_host) {
-              ACA_LOG_DEBUG("neighbor host: %s is on the same compute node, don't need to update L2 neighbor info.\n",
-                            host_ip_address.c_str());
-              overall_rc = EXIT_SUCCESS;
-            } else {
-              overall_rc = ACA_OVS_L2_Programmer::get_instance().create_update_neighbor_port(
+            if ((current_NeighborState.operation_type() == OperationType::CREATE) ||
+                (current_NeighborState.operation_type() == OperationType::UPDATE) ||
+                (current_NeighborState.operation_type() == OperationType::INFO)) {
+              overall_rc = ACA_OVS_L2_Programmer::get_instance().create_or_update_neighbor_port(
+                      current_NeighborConfiguration.id(),
                       current_NeighborConfiguration.vpc_id(), found_network_type, host_ip_address,
                       found_tunnel_id, culminative_dataplane_programming_time);
               // we can consider doing this L2 neighbor creation as an on demand rule to support scale
               // when we are ready to put the DVR rule as on demand, we should put the L2 neighbor rule
               // as on demand also
-            }
+            } else if (current_NeighborState.operation_type() == OperationType::DELETE) {
+              string outport_name =
+                      aca_get_outport_name(found_network_type, host_ip_address);
 
-            if (overall_rc == EXIT_SUCCESS) {
-              if (current_fixed_ip.neighbor_type() == NeighborType::L3) {
+              overall_rc = ACA_OVS_L2_Programmer::get_instance().delete_neighbor_port(
+                      current_NeighborConfiguration.id(),
+                      current_NeighborConfiguration.vpc_id(), outport_name,
+                      culminative_dataplane_programming_time);
+            } else {
+              ACA_LOG_ERROR("Invalid neighbor state operation type %d\n",
+                            current_NeighborState.operation_type());
+              overall_rc = -EXIT_FAILURE;
+            }
+          }
+
+          if (overall_rc == EXIT_SUCCESS) {
+            if (current_fixed_ip.neighbor_type() == NeighborType::L3) {
+              if ((current_NeighborState.operation_type() == OperationType::CREATE) ||
+                  (current_NeighborState.operation_type() == OperationType::UPDATE) ||
+                  (current_NeighborState.operation_type() == OperationType::INFO)) {
                 overall_rc = ACA_OVS_L3_Programmer::get_instance().create_or_update_neighbor_l3(
                         current_NeighborConfiguration.vpc_id(),
                         current_fixed_ip.subnet_id(), found_network_type,
                         virtual_ip_address, virtual_mac_address, host_ip_address,
                         found_tunnel_id, culminative_dataplane_programming_time);
+              } else if (current_NeighborState.operation_type() == OperationType::DELETE) {
+                // TBD: DELETE L3 neighbor
+              } else {
+                ACA_LOG_ERROR("Invalid neighbor state operation type %d\n",
+                              current_NeighborState.operation_type());
+                overall_rc = -EXIT_FAILURE;
               }
             }
           }
-        } else {
-          ACA_LOG_ERROR("Unknown neighbor_type: %d.\n",
-                        current_NeighborState.operation_type());
-          overall_rc = -EINVAL;
         }
+      } else {
+        ACA_LOG_ERROR("Unknown neighbor_type: %d.\n",
+                      current_NeighborState.operation_type());
+        overall_rc = -EINVAL;
+      }
 
-      } // for (int ip_index = 0; ip_index < current_NeighborConfiguration.fixed_ips_size(); ip_index++)
+    } // for (int ip_index = 0; ip_index < current_NeighborConfiguration.fixed_ips_size(); ip_index++)
 
-    } catch (const std::invalid_argument &e) {
-      ACA_LOG_ERROR("Invalid argument exception caught while parsing neighbor configuration, message: %s.\n",
-                    e.what());
-      overall_rc = -EINVAL;
-    } catch (const std::exception &e) {
-      ACA_LOG_ERROR("Exception caught while parsing neighbor configuration, message: %s.\n",
-                    e.what());
-      overall_rc = -EFAULT;
-    } catch (...) {
-      ACA_LOG_CRIT("%s", "Unknown exception caught while parsing neighbor configuration.\n");
-      overall_rc = -EFAULT;
-    }
-
-    break;
-
-  default:
-    ACA_LOG_ERROR("Invalid neighbor state operation type %d\n",
-                  current_NeighborState.operation_type());
-    overall_rc = -EXIT_FAILURE;
-    break;
+  } catch (const std::invalid_argument &e) {
+    ACA_LOG_ERROR("Invalid argument exception caught while parsing neighbor configuration, message: %s.\n",
+                  e.what());
+    overall_rc = -EINVAL;
+  } catch (const std::exception &e) {
+    ACA_LOG_ERROR("Exception caught while parsing neighbor configuration, message: %s.\n",
+                  e.what());
+    overall_rc = -EFAULT;
+  } catch (...) {
+    ACA_LOG_CRIT("%s", "Unknown exception caught while parsing neighbor configuration.\n");
+    overall_rc = -EFAULT;
   }
 
   auto operation_end = chrono::steady_clock::now();

--- a/src/ovs/aca_ovs_l2_programmer.cpp
+++ b/src/ovs/aca_ovs_l2_programmer.cpp
@@ -268,11 +268,11 @@ int ACA_OVS_L2_Programmer::delete_port(const string vpc_id, const string port_na
   return overall_rc;
 }
 
-int ACA_OVS_L2_Programmer::create_or_update_neighbor_port(
+int ACA_OVS_L2_Programmer::create_or_update_l2_neighbor(
         const string neighbor_id, const string vpc_id, alcor::schema::NetworkType network_type,
         const string remote_host_ip, uint tunnel_id, ulong &culminative_time)
 {
-  ACA_LOG_DEBUG("%s", "ACA_OVS_L2_Programmer::create_or_update_neighbor_port ---> Entering\n");
+  ACA_LOG_DEBUG("%s", "ACA_OVS_L2_Programmer::create_or_update_l2_neighbor ---> Entering\n");
 
   if (neighbor_id.empty()) {
     throw std::invalid_argument("neighbor_id is empty");
@@ -295,17 +295,16 @@ int ACA_OVS_L2_Programmer::create_or_update_neighbor_port(
   int overall_rc = ACA_Vlan_Manager::get_instance().create_neighbor_outport(
           neighbor_id, vpc_id, network_type, remote_host_ip, tunnel_id, culminative_time);
 
-  ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::create_or_update_neighbor_port <--- Exiting, overall_rc = %d\n",
+  ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::create_or_update_l2_neighbor <--- Exiting, overall_rc = %d\n",
                 overall_rc);
 
   return overall_rc;
 }
 
-int ACA_OVS_L2_Programmer::delete_neighbor_port(const string neighbor_id,
-                                                const string vpc_id, const string outport_name,
-                                                ulong &culminative_time)
+int ACA_OVS_L2_Programmer::delete_l2_neighbor(const string neighbor_id, const string vpc_id,
+                                              const string outport_name, ulong &culminative_time)
 {
-  ACA_LOG_DEBUG("%s", "ACA_OVS_L2_Programmer::delete_neighbor_port ---> Entering\n");
+  ACA_LOG_DEBUG("%s", "ACA_OVS_L2_Programmer::delete_l2_neighbor ---> Entering\n");
 
   if (neighbor_id.empty()) {
     throw std::invalid_argument("neighbor_id is empty");
@@ -322,7 +321,7 @@ int ACA_OVS_L2_Programmer::delete_neighbor_port(const string neighbor_id,
   int overall_rc = ACA_Vlan_Manager::get_instance().delete_neighbor_outport(
           neighbor_id, vpc_id, outport_name, culminative_time);
 
-  ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::delete_neighbor_port <--- Exiting, overall_rc = %d\n",
+  ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::delete_l2_neighbor <--- Exiting, overall_rc = %d\n",
                 overall_rc);
 
   return overall_rc;

--- a/src/ovs/aca_ovs_l2_programmer.cpp
+++ b/src/ovs/aca_ovs_l2_programmer.cpp
@@ -18,7 +18,6 @@
 #include "aca_net_config.h"
 #include "aca_vlan_manager.h"
 #include "aca_ovs_l2_programmer.h"
-#include "goalstateprovisioner.grpc.pb.h"
 #include <chrono>
 #include <thread>
 #include <errno.h>
@@ -155,11 +154,11 @@ int ACA_OVS_L2_Programmer::setup_ovs_bridges_if_need()
   return overall_rc;
 }
 
-int ACA_OVS_L2_Programmer::configure_port(const string vpc_id, const string port_name,
-                                          const string virtual_ip,
-                                          uint tunnel_id, ulong &culminative_time)
+int ACA_OVS_L2_Programmer::create_port(const string vpc_id, const string port_name,
+                                       const string virtual_ip, uint tunnel_id,
+                                       ulong &culminative_time)
 {
-  ACA_LOG_DEBUG("%s", "ACA_OVS_L2_Programmer::port_configure ---> Entering\n");
+  ACA_LOG_DEBUG("%s", "ACA_OVS_L2_Programmer::create_port ---> Entering\n");
 
   int overall_rc = EXIT_SUCCESS;
 
@@ -189,14 +188,7 @@ int ACA_OVS_L2_Programmer::configure_port(const string vpc_id, const string port
   // internal vlan id or to create a new vpc_id entry to get a new internal vlan id
   int internal_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(vpc_id);
 
-  ACA_Vlan_Manager::get_instance().add_ovs_port(vpc_id, port_name);
-
-  // table 4 = incoming vxlan, allow incoming vxlan traffic matching tunnel_id to
-  // stamp with internal vlan and deliver to br-int
-  execute_openflow_command(
-          "add-flow br-tun \"table=4, priority=1,tun_id=" + to_string(tunnel_id) +
-                  " actions=mod_vlan_vid:" + to_string(internal_vlan_id) + ",output:\"patch-int\"\"",
-          culminative_time, overall_rc);
+  ACA_Vlan_Manager::get_instance().create_ovs_port(vpc_id, port_name, tunnel_id, culminative_time);
 
   if (g_demo_mode) {
     string cmd_string = "add-port br-int " + port_name +
@@ -240,20 +232,51 @@ int ACA_OVS_L2_Programmer::configure_port(const string vpc_id, const string port
     }
   }
 
-  ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::port_configure <--- Exiting, overall_rc = %d\n",
-                overall_rc);
+  ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::create_port <--- Exiting, overall_rc = %d\n", overall_rc);
 
   return overall_rc;
 }
 
-int ACA_OVS_L2_Programmer::create_update_neighbor_port(const string vpc_id,
-                                                       alcor::schema::NetworkType network_type,
-                                                       const string remote_host_ip,
-                                                       uint tunnel_id, ulong &culminative_time)
+int ACA_OVS_L2_Programmer::delete_port(const string vpc_id, const string port_name,
+                                       uint tunnel_id, ulong &culminative_time)
 {
-  ACA_LOG_DEBUG("%s", "ACA_OVS_L2_Programmer::create_update_neighbor_port ---> Entering\n");
+  ACA_LOG_DEBUG("%s", "ACA_OVS_L2_Programmer::delete_port ---> Entering\n");
 
-  int overall_rc = EXIT_SUCCESS;
+  if (vpc_id.empty()) {
+    throw std::invalid_argument("vpc_id is empty");
+  }
+
+  if (port_name.empty()) {
+    throw std::invalid_argument("port_name is empty");
+  }
+
+  if (tunnel_id == 0) {
+    throw std::invalid_argument("tunnel_id is 0");
+  }
+
+  int overall_rc = ACA_Vlan_Manager::get_instance().delete_ovs_port(
+          vpc_id, port_name, tunnel_id, culminative_time);
+
+  if (g_demo_mode) {
+    string cmd_string = "del-port br-int " + port_name;
+
+    execute_ovsdb_command(cmd_string, culminative_time, overall_rc);
+  }
+
+  ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::delete_port <--- Exiting, overall_rc = %d\n", overall_rc);
+
+  return overall_rc;
+}
+
+int ACA_OVS_L2_Programmer::create_or_update_neighbor_port(
+        const string neighbor_id, const string vpc_id, alcor::schema::NetworkType network_type,
+        const string remote_host_ip, uint tunnel_id, ulong &culminative_time)
+{
+  ACA_LOG_DEBUG("%s", "ACA_OVS_L2_Programmer::create_or_update_neighbor_port ---> Entering\n");
+
+  if (neighbor_id.empty()) {
+    throw std::invalid_argument("neighbor_id is empty");
+  }
 
   if (vpc_id.empty()) {
     throw std::invalid_argument("vpc_id is empty");
@@ -269,44 +292,37 @@ int ACA_OVS_L2_Programmer::create_update_neighbor_port(const string vpc_id,
 
   string outport_name = aca_get_outport_name(network_type, remote_host_ip);
 
-  // create ovs outport for a particular remote_ip
-  string cmd_string =
-          "--may-exist add-port br-tun " + outport_name + " -- set interface " +
-          outport_name + " type=" + aca_get_network_type_string(network_type) +
-          " options:df_default=true options:egress_pkt_mark=0 options:in_key=flow options:out_key=flow options:remote_ip=" +
-          remote_host_ip;
+  int overall_rc = ACA_Vlan_Manager::get_instance().create_neighbor_outport(
+          neighbor_id, vpc_id, network_type, remote_host_ip, tunnel_id, culminative_time);
 
-  execute_ovsdb_command(cmd_string, culminative_time, overall_rc);
+  ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::create_or_update_neighbor_port <--- Exiting, overall_rc = %d\n",
+                overall_rc);
 
-  // use vpc_id to query vlan_manager to lookup an existing vpc_id entry to get its
-  // internal vlan id or to create a new vpc_id entry to get a new internal vlan id
-  int internal_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(vpc_id);
+  return overall_rc;
+}
 
-  ACA_Vlan_Manager::get_instance().add_outport(vpc_id, outport_name);
+int ACA_OVS_L2_Programmer::delete_neighbor_port(const string neighbor_id,
+                                                const string vpc_id, const string outport_name,
+                                                ulong &culminative_time)
+{
+  ACA_LOG_DEBUG("%s", "ACA_OVS_L2_Programmer::delete_neighbor_port ---> Entering\n");
 
-  string full_outport_list;
-  overall_rc = ACA_Vlan_Manager::get_instance().get_outports(vpc_id, full_outport_list);
-
-  if (overall_rc != EXIT_SUCCESS) {
-    throw std::runtime_error("vpc_id entry not found in vpc_table");
+  if (neighbor_id.empty()) {
+    throw std::invalid_argument("neighbor_id is empty");
   }
 
-  // match internal vlan based on VPC, output for all outports based on the same
-  // tunnel ID (multicast traffic)
-  cmd_string = "add-flow br-tun \"table=22,priority=1,dl_vlan=" + to_string(internal_vlan_id) +
-               " actions=strip_vlan,load:" + to_string(tunnel_id) +
-               "->NXM_NX_TUN_ID[]," + full_outport_list + "\"";
+  if (vpc_id.empty()) {
+    throw std::invalid_argument("vpc_id is empty");
+  }
 
-  execute_openflow_command(cmd_string, culminative_time, overall_rc);
+  if (outport_name.empty()) {
+    throw std::invalid_argument("outport_name is empty");
+  }
 
-  // incoming from neighbor through vxlan port (based on remote IP)
-  // [TBD] consider raising the priority to med based on design
-  cmd_string = "add-flow br-tun \"table=0,priority=1,in_port=\"" +
-               outport_name + "\" actions=resubmit(,4)\"";
+  int overall_rc = ACA_Vlan_Manager::get_instance().delete_neighbor_outport(
+          neighbor_id, vpc_id, outport_name, culminative_time);
 
-  execute_openflow_command(cmd_string, culminative_time, overall_rc);
-
-  ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::create_update_neighbor_port <--- Exiting, overall_rc = %d\n",
+  ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::delete_neighbor_port <--- Exiting, overall_rc = %d\n",
                 overall_rc);
 
   return overall_rc;

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -444,7 +444,7 @@ int ACA_OVS_L3_Programmer::delete_router(RouterConfiguration &current_RouterConf
 }
 
 int ACA_OVS_L3_Programmer::create_or_update_neighbor_l3(
-        const string vpc_id, const string subnet_id, alcor::schema::NetworkType /* network_type */,
+        const string neighbor_id, const string vpc_id, const string subnet_id,
         const string virtual_ip, const string virtual_mac,
         const string remote_host_ip, uint tunnel_id, ulong &culminative_time)
 {
@@ -455,6 +455,10 @@ int ACA_OVS_L3_Programmer::create_or_update_neighbor_l3(
   int source_vlan_id;
   int destination_vlan_id;
   string cmd_string;
+
+  if (neighbor_id.empty()) {
+    throw std::invalid_argument("neighbor_id is empty");
+  }
 
   if (vpc_id.empty()) {
     throw std::invalid_argument("vpc_id is empty");
@@ -472,11 +476,13 @@ int ACA_OVS_L3_Programmer::create_or_update_neighbor_l3(
     throw std::invalid_argument("virtual_mac is empty");
   }
 
+  if (remote_host_ip.empty()) {
+    throw std::invalid_argument("remote_host_ip is empty");
+  }
+
   if (tunnel_id == 0) {
     throw std::invalid_argument("tunnel_id is 0");
   }
-
-  // TODO: insert the port info into _routers_table, for use with on demand rule programming later
 
   bool is_port_on_same_host = aca_is_port_on_same_host(remote_host_ip);
 
@@ -498,8 +504,16 @@ int ACA_OVS_L3_Programmer::create_or_update_neighbor_l3(
       // for each other subnet connected to this router, create the routing rule
       for (auto subnet_it = router_it->second.begin();
            subnet_it != router_it->second.end(); subnet_it++) {
-        // skip the destination neighbor subnet
         if (subnet_it->first == subnet_id) {
+          // for the destination subnet, add the neighbor port to track it
+          neighbor_port_table_entry new_neighbor_port_table_entry;
+          new_neighbor_port_table_entry.virtual_ip = virtual_ip;
+          new_neighbor_port_table_entry.virtual_mac = virtual_mac;
+          new_neighbor_port_table_entry.host_ip = remote_host_ip;
+          subnet_it->second.neighbor_ports.emplace(neighbor_id, new_neighbor_port_table_entry);
+
+          // skip the destination neighbor subnet for the static routing rule below
+          // because routing rule are for source packet transformation
           continue;
         }
         ACA_LOG_DEBUG("subnet_id:%s\n ", subnet_it->first.c_str());
@@ -547,6 +561,96 @@ int ACA_OVS_L3_Programmer::create_or_update_neighbor_l3(
   }
 
   ACA_LOG_DEBUG("ACA_OVS_L3_Programmer::create_or_update_neighbor_l3 <--- Exiting, overall_rc = %d\n",
+                overall_rc);
+
+  return overall_rc;
+}
+
+int ACA_OVS_L3_Programmer::delete_neighbor_l3(const string neighbor_id, const string subnet_id,
+                                              const string virtual_ip, ulong &culminative_time)
+{
+  ACA_LOG_DEBUG("%s", "ACA_OVS_L3_Programmer::delete_neighbor_l3 ---> Entering\n");
+
+  int overall_rc = EXIT_SUCCESS;
+  bool found_subnet_in_router = false;
+  int source_vlan_id;
+
+  if (neighbor_id.empty()) {
+    throw std::invalid_argument("neighbor_id is empty");
+  }
+
+  if (subnet_id.empty()) {
+    throw std::invalid_argument("subnet_id is empty");
+  }
+
+  if (virtual_ip.empty()) {
+    throw std::invalid_argument("virtual_ip is empty");
+  }
+
+  // going through our list of routers
+  for (auto router_it = _routers_table.begin();
+       router_it != _routers_table.end(); router_it++) {
+    ACA_LOG_DEBUG("router ID:%s\n ", router_it->first.c_str());
+
+    // try to see if the destination subnet GW is connected to the current router
+    auto found_subnet = router_it->second.find(subnet_id);
+
+    if (found_subnet == router_it->second.end()) {
+      // subnet not found in this router, go look at the next router
+      continue;
+    } else {
+      // destination subnet found!
+      found_subnet_in_router = true;
+
+      // for each other subnet connected to this router, delete the routing rule
+      for (auto subnet_it = router_it->second.begin();
+           subnet_it != router_it->second.end(); subnet_it++) {
+        if (subnet_it->first == subnet_id) {
+          // for the destination subnet, remove the tracking neighbor port
+          if (subnet_it->second.neighbor_ports.erase(neighbor_id)) {
+            ACA_LOG_INFO("Successfuly cleaned up entry for neighbor_id %s\n",
+                         neighbor_id.c_str());
+            overall_rc = EXIT_SUCCESS;
+          } else {
+            ACA_LOG_ERROR("Failed to clean up entry for neighbor_id %s\n",
+                          neighbor_id.c_str());
+            overall_rc = EXIT_FAILURE;
+          }
+
+          // skip the destination neighbor subnet for the static routing rule below
+          // because routing rule are for source packet transformation
+          continue;
+        }
+        ACA_LOG_DEBUG("subnet_id:%s\n ", subnet_it->first.c_str());
+
+        source_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(
+                subnet_it->second.vpc_id);
+
+        // for the first implementation with static routing rules (non on-demand)
+        // go ahead to remove it
+        string cmd_string = "del-flow br-tun \"table=0,priority=50,ip,dl_vlan=" +
+                            to_string(source_vlan_id) + ",nw_dst=" + virtual_ip + "\" --strict";
+
+        ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
+                cmd_string, culminative_time, overall_rc);
+
+        // once we have the on demand routing rule implemented, we will need remove any
+        // on demand routing rule assoicated this deleted neighbor to stop the traffic
+        // immediately, we cannot rely on the rule's idle timout
+      }
+      // we found our interested router from _routers_table which has the destination subnet GW connected to it.
+      // Since each subnet GW can only be connected to one router, therefore, there is no point to look at other
+      // routers on the higher level for (auto router_it = _routers_table.begin();...) loop
+      break;
+    }
+  }
+
+  if (!found_subnet_in_router) {
+    ACA_LOG_ERROR("subnet_id %s not found in our local routers\n", subnet_id.c_str());
+    overall_rc = ENOENT;
+  }
+
+  ACA_LOG_DEBUG("ACA_OVS_L3_Programmer::delete_neighbor_l3 <--- Exiting, overall_rc = %d\n",
                 overall_rc);
 
   return overall_rc;

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -510,6 +510,7 @@ int ACA_OVS_L3_Programmer::create_or_update_neighbor_l3(
 
         // the openflow rule depends on whether the hosting ip is on this compute host or not
         if (is_port_on_same_host) {
+          // TODO: mod_dl_src to the destination gateway
           cmd_string = "add-flow br-tun \"table=0,priority=50,ip,dl_vlan=" +
                        to_string(source_vlan_id) + ",nw_dst=" + virtual_ip +
                        ",dl_dst=" + subnet_it->second.gateway_mac +

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -644,7 +644,7 @@ int ACA_OVS_L3_Programmer::delete_neighbor_l3(const string neighbor_id, const st
 
         // for the first implementation with static routing rules (non on-demand)
         // go ahead to remove it
-        string cmd_string = "del-flow br-tun \"table=0,priority=50,ip,dl_vlan=" +
+        string cmd_string = "del-flows br-tun \"table=0,priority=50,ip,dl_vlan=" +
                             to_string(source_vlan_id) + ",nw_dst=" + virtual_ip + "\" --strict";
 
         ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -387,59 +387,42 @@ int ACA_OVS_L3_Programmer::delete_router(RouterConfiguration &current_RouterConf
 
   auto router_subnet_routing_tables = _routers_table[router_id];
 
-  // for each subnet's gateway:
+  // for each connected subnet's gateway:
   for (auto subnet_it = router_subnet_routing_tables.begin();
        subnet_it != router_subnet_routing_tables.end(); subnet_it++) {
     string subnet_entry_to_delete = subnet_it->first.c_str();
     ACA_LOG_DEBUG("Subnet_id entry to delete:%s\n", subnet_entry_to_delete.c_str());
 
-    // see if there is still *any* other router still have this subnet connected
-    bool subnet_entry_to_delete_found = false;
-    for (auto all_routers_it : _routers_table) {
-      auto current_subnet_routing_tables = all_routers_it.second;
-      if (current_subnet_routing_tables.find(subnet_entry_to_delete) !=
-          current_subnet_routing_tables.end()) {
-        ACA_LOG_ERROR("Subnet_id entry to delete found! %s\n",
-                      subnet_entry_to_delete.c_str());
-        subnet_entry_to_delete_found = true;
-        break;
-      } else {
-        continue;
-      }
-    }
+    source_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(
+            subnet_it->second.vpc_id);
 
-    if (!subnet_entry_to_delete_found) {
-      source_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(
-              subnet_it->second.vpc_id);
+    current_gateway_mac = subnet_it->second.gateway_mac;
+    current_gateway_mac.erase(
+            remove(current_gateway_mac.begin(), current_gateway_mac.end(), ':'),
+            current_gateway_mac.end());
 
-      current_gateway_mac = subnet_it->second.gateway_mac;
-      current_gateway_mac.erase(
-              remove(current_gateway_mac.begin(), current_gateway_mac.end(), ':'),
-              current_gateway_mac.end());
+    // Delete Arp responder:
+    cmd_string = "del-flows br-tun \"table=51,arp,dl_vlan=" + to_string(source_vlan_id) +
+                 ",nw_dst=" + subnet_it->second.gateway_ip + "\"";
 
-      // Delete Arp responder:
-      cmd_string = "del-flows br-tun \"table=51,arp,dl_vlan=" + to_string(source_vlan_id) +
-                   ",nw_dst=" + subnet_it->second.gateway_ip + "\"";
+    ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
+            cmd_string, dataplane_programming_time, overall_rc);
 
-      ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
-              cmd_string, dataplane_programming_time, overall_rc);
+    // Delete ICMP responder:
+    cmd_string = "del-flows br-tun \"table=52,icmp,dl_vlan=" + to_string(source_vlan_id) +
+                 ",nw_dst=" + subnet_it->second.gateway_ip + "\"";
 
-      // Delete ICMP responder:
-      cmd_string = "del-flows br-tun \"table=52,icmp,dl_vlan=" + to_string(source_vlan_id) +
-                   ",nw_dst=" + subnet_it->second.gateway_ip + "\"";
+    ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
+            cmd_string, dataplane_programming_time, overall_rc);
 
-      ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
-              cmd_string, dataplane_programming_time, overall_rc);
+    // remove essential rule which restore from neighbor host DVR mac to destination GW mac
 
-      // remove essential rule to restore from neighbor host DVR mac to destination GW mac
+    // Note: all port from the same subnet on current host will share this rule
+    cmd_string = "del-flows br-int \"table=0,priority=25,dl_vlan=" + to_string(source_vlan_id) +
+                 ",dl_src=" + HOST_DVR_MAC_MATCH + "\" --strict";
 
-      // Note: all port from the same subnet on current host will share this rule
-      cmd_string = "del-flows br-int \"table=0,priority=25,dl_vlan=" + to_string(source_vlan_id) +
-                   ",dl_src=" + HOST_DVR_MAC_MATCH + "\" --strict";
-
-      ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
-              cmd_string, dataplane_programming_time, overall_rc);
-    }
+    ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
+            cmd_string, dataplane_programming_time, overall_rc);
   }
 
   // -----critical section starts-----

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -459,12 +459,12 @@ int ACA_OVS_L3_Programmer::delete_router(RouterConfiguration &current_RouterConf
   return overall_rc;
 }
 
-int ACA_OVS_L3_Programmer::create_or_update_neighbor_l3(
+int ACA_OVS_L3_Programmer::create_or_update_l3_neighbor(
         const string neighbor_id, const string vpc_id, const string subnet_id,
         const string virtual_ip, const string virtual_mac,
         const string remote_host_ip, uint tunnel_id, ulong &culminative_time)
 {
-  ACA_LOG_DEBUG("%s", "ACA_OVS_L3_Programmer::create_or_update_neighbor_l3 ---> Entering\n");
+  ACA_LOG_DEBUG("%s", "ACA_OVS_L3_Programmer::create_or_update_l3_neighbor ---> Entering\n");
 
   int overall_rc = EXIT_SUCCESS;
   bool found_subnet_in_router = false;
@@ -576,16 +576,16 @@ int ACA_OVS_L3_Programmer::create_or_update_neighbor_l3(
     overall_rc = ENOENT;
   }
 
-  ACA_LOG_DEBUG("ACA_OVS_L3_Programmer::create_or_update_neighbor_l3 <--- Exiting, overall_rc = %d\n",
+  ACA_LOG_DEBUG("ACA_OVS_L3_Programmer::create_or_update_l3_neighbor <--- Exiting, overall_rc = %d\n",
                 overall_rc);
 
   return overall_rc;
 }
 
-int ACA_OVS_L3_Programmer::delete_neighbor_l3(const string neighbor_id, const string subnet_id,
+int ACA_OVS_L3_Programmer::delete_l3_neighbor(const string neighbor_id, const string subnet_id,
                                               const string virtual_ip, ulong &culminative_time)
 {
-  ACA_LOG_DEBUG("%s", "ACA_OVS_L3_Programmer::delete_neighbor_l3 ---> Entering\n");
+  ACA_LOG_DEBUG("%s", "ACA_OVS_L3_Programmer::delete_l3_neighbor ---> Entering\n");
 
   int overall_rc = EXIT_SUCCESS;
   bool found_subnet_in_router = false;
@@ -666,7 +666,7 @@ int ACA_OVS_L3_Programmer::delete_neighbor_l3(const string neighbor_id, const st
     overall_rc = ENOENT;
   }
 
-  ACA_LOG_DEBUG("ACA_OVS_L3_Programmer::delete_neighbor_l3 <--- Exiting, overall_rc = %d\n",
+  ACA_LOG_DEBUG("ACA_OVS_L3_Programmer::delete_l3_neighbor <--- Exiting, overall_rc = %d\n",
                 overall_rc);
 
   return overall_rc;

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -42,6 +42,22 @@ ACA_OVS_L3_Programmer &ACA_OVS_L3_Programmer::get_instance()
   return instance;
 }
 
+void ACA_OVS_L3_Programmer::clear_all_data()
+{
+  ACA_LOG_DEBUG("%s", "ACA_OVS_L3_Programmer::clear_all_data ---> Entering\n");
+
+  // -----critical section starts-----
+  _routers_table_mutex.lock();
+  // All the elements in the unordered_map container are dropped:
+  // their destructors are called, and they are removed from the container,
+  // leaving _routers_table with a size of 0.
+  _routers_table.clear();
+  _routers_table_mutex.unlock();
+  // -----critical section ends-----
+
+  ACA_LOG_DEBUG("%s", "ACA_OVS_L3_Programmer::clear_all_data <--- Exiting\n");
+}
+
 int ACA_OVS_L3_Programmer::create_or_update_router(RouterConfiguration &current_RouterConfiguration,
                                                    GoalState &parsed_struct,
                                                    ulong &dataplane_programming_time)
@@ -516,7 +532,7 @@ int ACA_OVS_L3_Programmer::create_or_update_neighbor_l3(
           // because routing rule are for source packet transformation
           continue;
         }
-        ACA_LOG_DEBUG("subnet_id:%s\n ", subnet_it->first.c_str());
+        ACA_LOG_DEBUG("Found L3 neighbor subnet_id:%s\n ", subnet_it->first.c_str());
 
         source_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(
                 subnet_it->second.vpc_id);

--- a/src/ovs/aca_vlan_manager.cpp
+++ b/src/ovs/aca_vlan_manager.cpp
@@ -281,7 +281,7 @@ int ACA_Vlan_Manager::delete_neighbor_outport(string neighbor_id, string vpc_id,
         }
       }
 
-      // see if there is still *any* vpc still using this outport
+      // see if there is still *any* other vpc still using this outport
       bool outports_found = false;
       for (auto it : _vpcs_table) {
         auto current_outports_neighbors_table = it.second.outports_neighbors_table;

--- a/src/ovs/aca_vlan_manager.cpp
+++ b/src/ovs/aca_vlan_manager.cpp
@@ -163,7 +163,7 @@ int ACA_Vlan_Manager::delete_ovs_port(string vpc_id, string ovs_port,
   ACA_LOG_DEBUG("ACA_Vlan_Manager::delete_ovs_port <--- Exiting, overall_rc = %d\n", overall_rc);
 
   return overall_rc;
-} // namespace aca_vlan_manager
+}
 
 int ACA_Vlan_Manager::create_neighbor_outport(string neighbor_id, string vpc_id,
                                               alcor::schema::NetworkType network_type,

--- a/src/ovs/aca_vlan_manager.cpp
+++ b/src/ovs/aca_vlan_manager.cpp
@@ -39,7 +39,7 @@ void ACA_Vlan_Manager::create_entry_unsafe(string vpc_id)
 
   _vpcs_table.emplace(vpc_id, new_table_entry);
 
-  ACA_LOG_DEBUG("%s", "ACA_OVS_Programmer::create_entry_unsafe <--- Exiting\n");
+  ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::create_entry_unsafe <--- Exiting\n");
 }
 
 uint ACA_Vlan_Manager::get_or_create_vlan_id(string vpc_id)
@@ -55,7 +55,7 @@ uint ACA_Vlan_Manager::get_or_create_vlan_id(string vpc_id)
   _vpcs_table_mutex.unlock();
   // -----critical section ends-----
 
-  ACA_LOG_DEBUG("%s", "ACA_OVS_Programmer::acquire_vlan_id <--- Exiting\n");
+  ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::acquire_vlan_id <--- Exiting\n");
 
   return acquired_vlan_id;
 }
@@ -73,7 +73,7 @@ void ACA_Vlan_Manager::add_ovs_port(string vpc_id, string ovs_port)
   _vpcs_table_mutex.unlock();
   // -----critical section ends-----
 
-  ACA_LOG_DEBUG("%s", "ACA_OVS_Programmer::add_ovs_port <--- Exiting\n");
+  ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::add_ovs_port <--- Exiting\n");
 }
 
 // called when a port associated with a vpc on this host is deleted

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(
     gtest/aca_test_openflow.cpp
     gtest/aca_test_ovs_l2.cpp
     gtest/aca_test_ovs_l3.cpp
+    gtest/aca_test_ovs_util.cpp
 )
 
 # Link test executable against gtest & gtest_main

--- a/test/func_tests/gs_tests.cpp
+++ b/test/func_tests/gs_tests.cpp
@@ -548,17 +548,6 @@ void parse_goalstate(GoalState parsed_struct, GoalState GoalState_builder)
       assert(parsed_struct.vpc_states(i).configuration().subnet_ids(j).id() ==
              GoalState_builder.vpc_states(i).configuration().subnet_ids(j).id());
     }
-
-    assert(parsed_struct.vpc_states(i).configuration().routes_size() ==
-           GoalState_builder.vpc_states(i).configuration().routes_size());
-
-    for (int k = 0; k < parsed_struct.vpc_states(i).configuration().routes_size(); k++) {
-      assert(parsed_struct.vpc_states(i).configuration().routes(k).destination() ==
-             GoalState_builder.vpc_states(i).configuration().routes(k).destination());
-
-      assert(parsed_struct.vpc_states(i).configuration().routes(k).next_hop() ==
-             GoalState_builder.vpc_states(i).configuration().routes(k).next_hop());
-    }
   }
 
   fprintf(stdout, "All content matched!\n");
@@ -667,7 +656,8 @@ int main(int argc, char *argv[])
 
   GoalState parsed_struct;
 
-  rc = Aca_Comm_Manager::get_instance().deserialize((const unsigned char*)buffer, size, parsed_struct);
+  rc = Aca_Comm_Manager::get_instance().deserialize(
+          (const unsigned char *)buffer, size, parsed_struct);
 
   if (buffer != NULL) {
     free(buffer);

--- a/test/gtest/aca_test_ovs_l2.cpp
+++ b/test/gtest/aca_test_ovs_l2.cpp
@@ -677,9 +677,9 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)
   EXPECT_NE(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
-  // just clearing the port states and reuse the rest GoalState_builder2
+  // just clearing the port states and reuse the rest GoalState_builder
   new_port_states->clear_configuration();
-  GoalState_builder2.clear_port_states();
+  GoalState_builder.clear_port_states();
 
   // delete port 4 as L2 neighbor
   new_neighbor_states->set_operation_type(OperationType::DELETE);

--- a/test/gtest/aca_test_ovs_l2.cpp
+++ b/test/gtest/aca_test_ovs_l2.cpp
@@ -178,7 +178,7 @@ TEST(ovs_l2_test_cases, 2_ports_CREATE_test_traffic_plus_neighbor_internal)
   string outport_name = aca_get_outport_name(vxlan_type, remote_ip_1);
 
   // insert neighbor info
-  overall_rc = ACA_OVS_L2_Programmer::get_instance().create_or_update_neighbor_port(
+  overall_rc = ACA_OVS_L2_Programmer::get_instance().create_or_update_l2_neighbor(
           port_id_4, vpc_id_1, vxlan_type, remote_ip_1, 20, not_care_culminative_time);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
@@ -190,7 +190,7 @@ TEST(ovs_l2_test_cases, 2_ports_CREATE_test_traffic_plus_neighbor_internal)
   overall_rc = EXIT_SUCCESS;
 
   // delete neighbor info
-  overall_rc = ACA_OVS_L2_Programmer::get_instance().delete_neighbor_port(
+  overall_rc = ACA_OVS_L2_Programmer::get_instance().delete_l2_neighbor(
           port_id_4, vpc_id_1, outport_name, not_care_culminative_time);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;

--- a/test/gtest/aca_test_ovs_l2.cpp
+++ b/test/gtest/aca_test_ovs_l2.cpp
@@ -31,36 +31,42 @@ using aca_comm_manager::Aca_Comm_Manager;
 using aca_net_config::Aca_Net_Config;
 using aca_ovs_l2_programmer::ACA_OVS_L2_Programmer;
 
-string project_id = "99d9d709-8478-4b46-9f3f-000000000000";
-string vpc_id_1 = "1b08a5bc-b718-11ea-b3de-111111111111";
-string vpc_id_2 = "1b08a5bc-b718-11ea-b3de-222222222222";
-string subnet_id_1 = "27330ae4-b718-11ea-b3de-111111111111";
-string subnet_id_2 = "27330ae4-b718-11ea-b3de-222222222222";
-string port_id_1 = "01111111-b718-11ea-b3de-111111111111";
-string port_id_2 = "02222222-b718-11ea-b3de-111111111111";
-string port_id_3 = "03333333-b718-11ea-b3de-111111111111";
-string port_id_4 = "04444444-b718-11ea-b3de-111111111111";
-string port_name_1 = aca_get_port_name(port_id_1);
-string port_name_2 = aca_get_port_name(port_id_2);
-string port_name_3 = aca_get_port_name(port_id_3);
-string port_name_4 = aca_get_port_name(port_id_4);
-string vmac_address_1 = "fa:16:3e:d7:f2:6c";
-string vmac_address_2 = "fa:16:3e:d7:f2:6d";
-string vmac_address_3 = "fa:16:3e:d7:f2:6e";
-string vmac_address_4 = "fa:16:3e:d7:f2:6f";
-string vip_address_1 = "10.10.0.101";
-string vip_address_2 = "10.10.1.102";
-string vip_address_3 = "10.10.0.103";
-string vip_address_4 = "10.10.1.104";
-NetworkType vxlan_type = NetworkType::VXLAN;
-string subnet1_gw_ip = "10.10.0.1";
-string subnet2_gw_ip = "10.10.1.1";
-string subnet1_gw_mac = "fa:16:3e:d7:f2:11";
-string subnet2_gw_mac = "fa:16:3e:d7:f2:21";
-
+// extern the string and helper functions from aca_test_ovs_util.cpp
+extern string project_id;
+extern string vpc_id_1;
+extern string vpc_id_2;
+extern string subnet_id_1;
+extern string subnet_id_2;
+extern string port_id_1;
+extern string port_id_2;
+extern string port_id_3;
+extern string port_id_4;
+extern string port_name_1;
+extern string port_name_2;
+extern string port_name_3;
+extern string port_name_4;
+extern string vmac_address_1;
+extern string vmac_address_2;
+extern string vmac_address_3;
+extern string vmac_address_4;
+extern string vip_address_1;
+extern string vip_address_2;
+extern string vip_address_3;
+extern string vip_address_4;
 extern string remote_ip_1; // for docker network
 extern string remote_ip_2; // for docker network
+extern NetworkType vxlan_type;
+extern string subnet1_gw_ip;
+extern string subnet2_gw_ip;
+extern string subnet1_gw_mac;
+extern string subnet2_gw_mac;
 extern bool g_demo_mode;
+
+extern void aca_test_create_default_port_state(PortState *new_port_states);
+extern void aca_test_create_default_subnet_state(SubnetState *new_subnet_states);
+extern void aca_test_1_neighbor_CREATE_DELETE(NeighborType input_neighbor_type);
+extern void aca_test_1_port_CREATE_plus_neighbor_CREATE(NeighborType input_neighbor_type);
+extern void aca_test_10_neighbor_CREATE(NeighborType input_neighbor_type);
 
 // TODO: setup bridge when br-int is up and br-tun is gone
 
@@ -75,49 +81,6 @@ extern bool g_demo_mode;
 // TODO: neighbor invalid IP
 
 // TODO: neighbor invalid mac
-
-void aca_test_create_default_port_state(PortState *new_port_states)
-{
-  new_port_states->set_operation_type(OperationType::CREATE);
-
-  PortConfiguration *PortConfiguration_builder = new_port_states->mutable_configuration();
-  PortConfiguration_builder->set_revision_number(1);
-  PortConfiguration_builder->set_message_type(MessageType::FULL);
-  PortConfiguration_builder->set_id(port_id_1);
-
-  PortConfiguration_builder->set_project_id(project_id);
-  PortConfiguration_builder->set_vpc_id(vpc_id_1);
-  PortConfiguration_builder->set_name(port_name_1);
-  PortConfiguration_builder->set_mac_address(vmac_address_1);
-  PortConfiguration_builder->set_admin_state_up(true);
-
-  PortConfiguration_FixedIp *FixedIp_builder = PortConfiguration_builder->add_fixed_ips();
-  FixedIp_builder->set_subnet_id(subnet_id_1);
-  FixedIp_builder->set_ip_address(vip_address_1);
-
-  PortConfiguration_SecurityGroupId *SecurityGroup_builder =
-          PortConfiguration_builder->add_security_group_ids();
-  SecurityGroup_builder->set_id("1");
-}
-
-void aca_test_create_default_subnet_state(SubnetState *new_subnet_states)
-{
-  new_subnet_states->set_operation_type(OperationType::INFO);
-
-  SubnetConfiguration *SubnetConiguration_builder =
-          new_subnet_states->mutable_configuration();
-  SubnetConiguration_builder->set_revision_number(1);
-  SubnetConiguration_builder->set_project_id(project_id);
-  SubnetConiguration_builder->set_vpc_id(vpc_id_1);
-  SubnetConiguration_builder->set_id(subnet_id_1);
-  SubnetConiguration_builder->set_cidr("10.0.0.0/24");
-  SubnetConiguration_builder->set_tunnel_id(20);
-
-  auto *subnetConfig_GatewayBuilder(new SubnetConfiguration_Gateway);
-  subnetConfig_GatewayBuilder->set_ip_address(subnet1_gw_ip);
-  subnetConfig_GatewayBuilder->set_mac_address(subnet1_gw_mac);
-  SubnetConiguration_builder->set_allocated_gateway(subnetConfig_GatewayBuilder);
-}
 
 //
 // Test suite: ovs_l2_test_cases
@@ -261,7 +224,7 @@ TEST(ovs_l2_test_cases, 2_ports_CREATE_test_traffic_plus_neighbor_internal)
   overall_rc = EXIT_SUCCESS;
 }
 
-TEST(ovs_l2_test_cases, 1_port_CREATE_DELETE_demo_mode)
+TEST(ovs_l2_test_cases, 1_port_CREATE_DELETE)
 {
   ulong not_care_culminative_time = 0;
   string cmd_string;
@@ -319,190 +282,6 @@ TEST(ovs_l2_test_cases, 1_port_CREATE_DELETE_demo_mode)
 
   // free the allocated configurations since we are done with it now
   new_port_states->clear_configuration();
-  new_subnet_states->clear_configuration();
-
-  // delete br-int and br-tun bridges
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-int", not_care_culminative_time, overall_rc);
-  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
-
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-tun", not_care_culminative_time, overall_rc);
-  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
-}
-
-TEST(ovs_l2_test_cases, 1_l2_neighbor_CREATE_DELETE)
-{
-  ulong not_care_culminative_time = 0;
-  string cmd_string;
-  int overall_rc;
-
-  // delete br-int and br-tun bridges
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-int", not_care_culminative_time, overall_rc);
-
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-tun", not_care_culminative_time, overall_rc);
-
-  // create and setup br-int and br-tun bridges, and their patch ports
-  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
-  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
-
-  GoalState GoalState_builder;
-  NeighborState *new_neighbor_states = GoalState_builder.add_neighbor_states();
-  SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
-
-  new_neighbor_states->set_operation_type(OperationType::CREATE);
-
-  // fill in neighbor state structs
-  NeighborConfiguration *NeighborConfiguration_builder =
-          new_neighbor_states->mutable_configuration();
-  NeighborConfiguration_builder->set_revision_number(1);
-
-  NeighborConfiguration_builder->set_project_id(project_id);
-  NeighborConfiguration_builder->set_vpc_id(vpc_id_1);
-  NeighborConfiguration_builder->set_id(port_id_3);
-  NeighborConfiguration_builder->set_mac_address(vmac_address_3);
-  NeighborConfiguration_builder->set_host_ip_address("172.17.111.222");
-
-  NeighborConfiguration_FixedIp *FixedIp_builder =
-          NeighborConfiguration_builder->add_fixed_ips();
-  FixedIp_builder->set_neighbor_type(NeighborType::L2);
-  FixedIp_builder->set_subnet_id(subnet_id_1);
-  FixedIp_builder->set_ip_address(vip_address_3);
-
-  // fill in subnet state structs
-  aca_test_create_default_subnet_state(new_subnet_states);
-
-  GoalStateOperationReply gsOperationalReply;
-
-  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
-          GoalState_builder, gsOperationalReply);
-  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
-
-  string outport_name = aca_get_outport_name(vxlan_type, "172.17.111.222");
-
-  // check if the outport has been created on br-tun
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          " list-ports br-tun | grep " + outport_name, not_care_culminative_time, overall_rc);
-  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
-
-  // delete neighbor info
-  new_neighbor_states->set_operation_type(OperationType::DELETE);
-  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
-          GoalState_builder, gsOperationalReply);
-  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
-
-  // check if the outport has been deleted on br-tun
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          " list-ports br-tun | grep " + outport_name, not_care_culminative_time, overall_rc);
-  EXPECT_NE(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
-
-  // clean up
-
-  // free the allocated configurations since we are done with it now
-  new_neighbor_states->clear_configuration();
-  new_subnet_states->clear_configuration();
-
-  // delete br-int and br-tun bridges
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-int", not_care_culminative_time, overall_rc);
-  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
-
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-tun", not_care_culminative_time, overall_rc);
-  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
-}
-
-TEST(ovs_l2_test_cases, 1_port_CREATE_plus_neighbor_CREATE)
-{
-  ulong not_care_culminative_time = 0;
-  string cmd_string;
-  int overall_rc;
-
-  // delete br-int and br-tun bridges
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-int", not_care_culminative_time, overall_rc);
-
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-tun", not_care_culminative_time, overall_rc);
-
-  // create and setup br-int and br-tun bridges, and their patch ports
-  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
-  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
-
-  GoalState GoalState_builder;
-  PortState *new_port_states = GoalState_builder.add_port_states();
-  SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
-
-  // fill in port state structs
-  aca_test_create_default_port_state(new_port_states);
-
-  // fill in subnet state structs
-  aca_test_create_default_subnet_state(new_subnet_states);
-
-  // add a new neighbor state with CREATE
-  NeighborState *new_neighbor_states = GoalState_builder.add_neighbor_states();
-  new_neighbor_states->set_operation_type(OperationType::CREATE);
-
-  // fill in neighbor state structs
-  NeighborConfiguration *NeighborConfiguration_builder =
-          new_neighbor_states->mutable_configuration();
-  NeighborConfiguration_builder->set_revision_number(1);
-
-  NeighborConfiguration_builder->set_project_id(project_id);
-  NeighborConfiguration_builder->set_vpc_id(vpc_id_1);
-  NeighborConfiguration_builder->set_id(port_id_3);
-  NeighborConfiguration_builder->set_mac_address(vmac_address_3);
-  NeighborConfiguration_builder->set_host_ip_address("172.17.111.222");
-
-  NeighborConfiguration_FixedIp *FixedIp_builder =
-          NeighborConfiguration_builder->add_fixed_ips();
-  FixedIp_builder->set_neighbor_type(NeighborType::L2);
-  FixedIp_builder->set_subnet_id(subnet_id_1);
-  FixedIp_builder->set_ip_address(vip_address_3);
-
-  // set demo mode
-  bool previous_demo_mode = g_demo_mode;
-  g_demo_mode = true;
-
-  // configure the whole goal state in demo mode
-  GoalStateOperationReply gsOperationalReply;
-
-  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
-          GoalState_builder, gsOperationalReply);
-  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
-
-  // restore demo mode
-  g_demo_mode = previous_demo_mode;
-
-  // check to ensure the port 1 is created and setup correctly
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "get Interface " + port_name_1 + " ofport", not_care_culminative_time, overall_rc);
-  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
-
-  string outport_name = aca_get_outport_name(vxlan_type, "172.17.111.222");
-
-  // check if the outport has been created on br-tun
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          " list-ports br-tun | grep " + outport_name, not_care_culminative_time, overall_rc);
-  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
-
-  // clean up
-
-  // free the allocated configurations since we are done with it now
-  new_port_states->clear_configuration();
-  new_neighbor_states->clear_configuration();
   new_subnet_states->clear_configuration();
 
   // delete br-int and br-tun bridges
@@ -717,105 +496,19 @@ TEST(ovs_l2_test_cases, 10_ports_CREATE)
                gsOperationReply.message_total_operation_time() / 1000000);
 }
 
+TEST(ovs_l2_test_cases, 1_l2_neighbor_CREATE_DELETE)
+{
+  aca_test_1_neighbor_CREATE_DELETE(NeighborType::L2);
+}
+
+TEST(ovs_l2_test_cases, 1_port_CREATE_plus_l2_neighbor_CREATE)
+{
+  aca_test_1_port_CREATE_plus_neighbor_CREATE(NeighborType::L2);
+}
+
 TEST(ovs_l2_test_cases, 10_l2_neighbor_CREATE)
 {
-  string port_name_postfix = "-2222-3333-4444-555555555555";
-  string neighbor_id_postfix = "-baad-f00d-4444-555555555555";
-  string ip_address_prefix = "10.0.0.";
-  string remote_ip_address_prefix = "123.0.0.";
-  ulong not_care_culminative_time = 0;
-  int overall_rc;
-
-  // delete br-int and br-tun bridges
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-int", not_care_culminative_time, overall_rc);
-
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-tun", not_care_culminative_time, overall_rc);
-
-  // create and setup br-int and br-tun bridges, and their patch ports
-  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
-  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
-
-  GoalState GoalState_builder;
-  NeighborState *new_neighbor_states;
-  SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
-  new_subnet_states->set_operation_type(OperationType::INFO);
-
-  SubnetConfiguration *SubnetConiguration_builder =
-          new_subnet_states->mutable_configuration();
-  SubnetConiguration_builder->set_revision_number(1);
-  SubnetConiguration_builder->set_project_id(project_id);
-  SubnetConiguration_builder->set_vpc_id("1b08a5bc-b718-11ea-b3de-111122223333");
-  SubnetConiguration_builder->set_id(subnet_id_1);
-  SubnetConiguration_builder->set_cidr("10.0.0.0/24");
-  SubnetConiguration_builder->set_tunnel_id(123);
-
-  auto *subnetConfig_GatewayBuilder(new SubnetConfiguration_Gateway);
-  subnetConfig_GatewayBuilder->set_ip_address(subnet1_gw_ip);
-  subnetConfig_GatewayBuilder->set_mac_address(subnet1_gw_mac);
-  SubnetConiguration_builder->set_allocated_gateway(subnetConfig_GatewayBuilder);
-
-  const int L2_NEIGHBOR_TO_CREATE = 10;
-
-  for (int i = 0; i < L2_NEIGHBOR_TO_CREATE; i++) {
-    string i_string = std::to_string(i);
-    string neighbor_id = i_string + neighbor_id_postfix;
-    string port_name = i_string + port_name_postfix;
-
-    new_neighbor_states = GoalState_builder.add_neighbor_states();
-    new_neighbor_states->set_operation_type(OperationType::CREATE);
-
-    NeighborConfiguration *NeighborConfiguration_builder =
-            new_neighbor_states->mutable_configuration();
-    NeighborConfiguration_builder->set_revision_number(1);
-
-    NeighborConfiguration_builder->set_project_id(project_id);
-    NeighborConfiguration_builder->set_vpc_id("1b08a5bc-b718-11ea-b3de-111122223333");
-    NeighborConfiguration_builder->set_id(neighbor_id);
-    NeighborConfiguration_builder->set_name(port_name);
-    NeighborConfiguration_builder->set_mac_address(vmac_address_1);
-    NeighborConfiguration_builder->set_host_ip_address(remote_ip_address_prefix + i_string);
-
-    NeighborConfiguration_FixedIp *FixedIp_builder =
-            NeighborConfiguration_builder->add_fixed_ips();
-    FixedIp_builder->set_neighbor_type(NeighborType::L2);
-    FixedIp_builder->set_subnet_id(subnet_id_1);
-    FixedIp_builder->set_ip_address(ip_address_prefix + i_string);
-  }
-
-  bool previous_demo_mode = g_demo_mode;
-  g_demo_mode = false;
-
-  GoalStateOperationReply gsOperationReply;
-  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
-          GoalState_builder, gsOperationReply);
-  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
-
-  g_demo_mode = previous_demo_mode;
-
-  // calculate the average latency
-  ulong total_neighbor_create_time = 0;
-
-  for (int i = 0; i < L2_NEIGHBOR_TO_CREATE; i++) {
-    ACA_LOG_DEBUG("Neighbor State(%d) took: %u nanoseconds or %u milliseconds\n",
-                  i, gsOperationReply.operation_statuses(i).state_elapse_time(),
-                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000000);
-
-    total_neighbor_create_time +=
-            gsOperationReply.operation_statuses(i).state_elapse_time();
-  }
-
-  ulong average_neighbor_create_time = total_neighbor_create_time / L2_NEIGHBOR_TO_CREATE;
-
-  ACA_LOG_INFO("Average L2 Neighbor Create of %d took: %lu nanoseconds or %lu milliseconds\n",
-               L2_NEIGHBOR_TO_CREATE, average_neighbor_create_time,
-               average_neighbor_create_time / 1000000);
-
-  ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u nanoseconds or %u milliseconds\n",
-               gsOperationReply.message_total_operation_time(),
-               gsOperationReply.message_total_operation_time() / 1000000);
+  aca_test_10_neighbor_CREATE(NeighborType::L2);
 }
 
 TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)

--- a/test/gtest/aca_test_ovs_l2.cpp
+++ b/test/gtest/aca_test_ovs_l2.cpp
@@ -677,9 +677,9 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)
   EXPECT_NE(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
-  // free the allocated configurations since we are done with it now
+  // just clearing the port states and reuse the rest GoalState_builder2
   new_port_states->clear_configuration();
-  new_subnet_states->clear_configuration();
+  GoalState_builder2.clear_port_states();
 
   // delete port 4 as L2 neighbor
   new_neighbor_states->set_operation_type(OperationType::DELETE);
@@ -704,6 +704,7 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)
 
   // free the allocated configurations since we are done with it now
   new_neighbor_states->clear_configuration();
+  new_subnet_states->clear_configuration();
 
   // delete br-int and br-tun bridges
   ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(

--- a/test/gtest/aca_test_ovs_l3.cpp
+++ b/test/gtest/aca_test_ovs_l3.cpp
@@ -342,7 +342,6 @@ TEST(ovs_l3_test_cases, DISABLED_2_ports_ROUTING_test_traffic_one_machine)
 
   // free the allocated configurations since we are done with it now
   new_port_states->clear_configuration();
-  new_subnet_states->clear_configuration();
 
   // program the router
   GoalState GoalState_builder2;
@@ -719,11 +718,6 @@ TEST(ovs_l3_test_cases, DISABLED_2_ports_ROUTING_test_traffic_PARENT)
           "docker exec con2 ping -c1 " + vip_address_3);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
 
-  // free the allocated configurations since we are done with it now
-  new_neighbor_states3->clear_configuration();
-  new_subnet_states1->clear_configuration();
-  new_subnet_states2->clear_configuration();
-
   // delete port 4 as L3 neighbor
   new_neighbor_states4->set_operation_type(OperationType::DELETE);
   overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
@@ -743,6 +737,9 @@ TEST(ovs_l3_test_cases, DISABLED_2_ports_ROUTING_test_traffic_PARENT)
   // cleanup
 
   // free the allocated configurations since we are done with it now
+  new_subnet_states1->clear_configuration();
+  new_subnet_states2->clear_configuration();
+  new_neighbor_states3->clear_configuration();
   new_neighbor_states4->clear_configuration();
 
   overall_rc = Aca_Net_Config::get_instance().execute_system_command("docker kill con1");

--- a/test/gtest/aca_test_ovs_l3.cpp
+++ b/test/gtest/aca_test_ovs_l3.cpp
@@ -451,6 +451,7 @@ TEST(ovs_l3_test_cases, DISABLED_2_ports_ROUTING_test_traffic_one_machine)
 
   NeighborConfiguration_builder3->set_project_id(project_id);
   NeighborConfiguration_builder3->set_vpc_id(vpc_id_1);
+  NeighborConfiguration_builder3->set_id(port_id_3);
   NeighborConfiguration_builder3->set_name(port_name_3);
   NeighborConfiguration_builder3->set_mac_address(vmac_address_3);
   NeighborConfiguration_builder3->set_host_ip_address(remote_ip_2);
@@ -470,6 +471,7 @@ TEST(ovs_l3_test_cases, DISABLED_2_ports_ROUTING_test_traffic_one_machine)
 
   NeighborConfiguration_builder4->set_project_id(project_id);
   NeighborConfiguration_builder4->set_vpc_id(vpc_id_2);
+  NeighborConfiguration_builder4->set_id(port_id_4);
   NeighborConfiguration_builder4->set_name(port_name_4);
   NeighborConfiguration_builder4->set_mac_address(vmac_address_4);
   NeighborConfiguration_builder4->set_host_ip_address(remote_ip_2);
@@ -779,6 +781,7 @@ TEST(ovs_l3_test_cases, DISABLED_2_ports_ROUTING_test_traffic_PARENT)
 
   NeighborConfiguration_builder3->set_project_id(project_id);
   NeighborConfiguration_builder3->set_vpc_id(vpc_id_1);
+  NeighborConfiguration_builder3->set_id(port_id_3);
   NeighborConfiguration_builder3->set_name(port_name_3);
   NeighborConfiguration_builder3->set_mac_address(vmac_address_3);
   NeighborConfiguration_builder3->set_host_ip_address(remote_ip_2);
@@ -798,6 +801,7 @@ TEST(ovs_l3_test_cases, DISABLED_2_ports_ROUTING_test_traffic_PARENT)
 
   NeighborConfiguration_builder4->set_project_id(project_id);
   NeighborConfiguration_builder4->set_vpc_id(vpc_id_2);
+  NeighborConfiguration_builder4->set_id(port_id_4);
   NeighborConfiguration_builder4->set_name(port_name_4);
   NeighborConfiguration_builder4->set_mac_address(vmac_address_4);
   NeighborConfiguration_builder4->set_host_ip_address(remote_ip_2);
@@ -1095,6 +1099,7 @@ TEST(ovs_l3_test_cases, DISABLED_2_ports_ROUTING_test_traffic_CHILD)
 
   NeighborConfiguration_builder3->set_project_id(project_id);
   NeighborConfiguration_builder3->set_vpc_id(vpc_id_1);
+  NeighborConfiguration_builder3->set_id(port_id_1);
   NeighborConfiguration_builder3->set_name(port_name_1);
   NeighborConfiguration_builder3->set_mac_address(vmac_address_1);
   NeighborConfiguration_builder3->set_host_ip_address(remote_ip_1);
@@ -1114,6 +1119,7 @@ TEST(ovs_l3_test_cases, DISABLED_2_ports_ROUTING_test_traffic_CHILD)
 
   NeighborConfiguration_builder4->set_project_id(project_id);
   NeighborConfiguration_builder4->set_vpc_id(vpc_id_2);
+  NeighborConfiguration_builder4->set_id(port_id_2);
   NeighborConfiguration_builder4->set_name(port_name_2);
   NeighborConfiguration_builder4->set_mac_address(vmac_address_2);
   NeighborConfiguration_builder4->set_host_ip_address(remote_ip_1);

--- a/test/gtest/aca_test_ovs_l3.cpp
+++ b/test/gtest/aca_test_ovs_l3.cpp
@@ -721,7 +721,7 @@ TEST(ovs_l3_test_cases, DISABLED_2_ports_ROUTING_test_traffic_PARENT)
   // delete port 4 as L3 neighbor
   new_neighbor_states4->set_operation_type(OperationType::DELETE);
   overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
-          GoalState_builder, gsOperationalReply);
+          GoalState_builder2, gsOperationalReply);
   ASSERT_EQ(overall_rc, EXIT_SUCCESS);
 
   // should not be able to ping port 4 anymore

--- a/test/gtest/aca_test_ovs_util.cpp
+++ b/test/gtest/aca_test_ovs_util.cpp
@@ -1,0 +1,432 @@
+// Copyright 2019 The Alcor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "aca_log.h"
+#include "aca_util.h"
+#include "aca_config.h"
+#include "aca_vlan_manager.h"
+#include "aca_ovs_l2_programmer.h"
+#include "aca_ovs_l3_programmer.h"
+#include "aca_comm_mgr.h"
+#include "gtest/gtest.h"
+#include "goalstate.pb.h"
+#include <unistd.h> /* for getopt */
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace alcor::schema;
+using namespace aca_vlan_manager;
+using namespace aca_ovs_l2_programmer;
+using namespace aca_ovs_l3_programmer;
+using aca_comm_manager::Aca_Comm_Manager;
+using aca_net_config::Aca_Net_Config;
+
+string project_id = "99d9d709-8478-4b46-9f3f-000000000000";
+string vpc_id_1 = "1b08a5bc-b718-11ea-b3de-111111111111";
+string vpc_id_2 = "1b08a5bc-b718-11ea-b3de-222222222222";
+string subnet_id_1 = "27330ae4-b718-11ea-b3de-111111111111";
+string subnet_id_2 = "27330ae4-b718-11ea-b3de-222222222222";
+string port_id_1 = "01111111-b718-11ea-b3de-111111111111";
+string port_id_2 = "02222222-b718-11ea-b3de-111111111111";
+string port_id_3 = "03333333-b718-11ea-b3de-111111111111";
+string port_id_4 = "04444444-b718-11ea-b3de-111111111111";
+string port_name_1 = aca_get_port_name(port_id_1);
+string port_name_2 = aca_get_port_name(port_id_2);
+string port_name_3 = aca_get_port_name(port_id_3);
+string port_name_4 = aca_get_port_name(port_id_4);
+string vmac_address_1 = "fa:16:3e:d7:f2:6c";
+string vmac_address_2 = "fa:16:3e:d7:f2:6d";
+string vmac_address_3 = "fa:16:3e:d7:f2:6e";
+string vmac_address_4 = "fa:16:3e:d7:f2:6f";
+string vip_address_1 = "10.10.0.101";
+string vip_address_2 = "10.10.1.102";
+string vip_address_3 = "10.10.0.103";
+string vip_address_4 = "10.10.1.104";
+NetworkType vxlan_type = NetworkType::VXLAN;
+string subnet1_gw_ip = "10.10.0.1";
+string subnet2_gw_ip = "10.10.1.1";
+string subnet1_gw_mac = "fa:16:3e:d7:f2:11";
+string subnet2_gw_mac = "fa:16:3e:d7:f2:21";
+
+extern bool g_demo_mode;
+
+void aca_test_reset_environment()
+{
+  ulong not_care_culminative_time = 0;
+  int overall_rc = EXIT_SUCCESS;
+
+  ACA_Vlan_Manager::get_instance().clear_all_data();
+
+  ACA_OVS_L3_Programmer::get_instance().clear_all_data();
+
+  // delete br-int and br-tun bridges
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-int", not_care_culminative_time, overall_rc);
+
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-tun", not_care_culminative_time, overall_rc);
+
+  // create and setup br-int and br-tun bridges, and their patch ports
+  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+}
+
+void aca_test_create_default_port_state(PortState *new_port_states)
+{
+  new_port_states->set_operation_type(OperationType::CREATE);
+
+  PortConfiguration *PortConfiguration_builder = new_port_states->mutable_configuration();
+  PortConfiguration_builder->set_revision_number(1);
+  PortConfiguration_builder->set_message_type(MessageType::FULL);
+  PortConfiguration_builder->set_id(port_id_1);
+
+  PortConfiguration_builder->set_project_id(project_id);
+  PortConfiguration_builder->set_vpc_id(vpc_id_1);
+  PortConfiguration_builder->set_name(port_name_1);
+  PortConfiguration_builder->set_mac_address(vmac_address_1);
+  PortConfiguration_builder->set_admin_state_up(true);
+
+  PortConfiguration_FixedIp *FixedIp_builder = PortConfiguration_builder->add_fixed_ips();
+  FixedIp_builder->set_subnet_id(subnet_id_1);
+  FixedIp_builder->set_ip_address(vip_address_1);
+
+  PortConfiguration_SecurityGroupId *SecurityGroup_builder =
+          PortConfiguration_builder->add_security_group_ids();
+  SecurityGroup_builder->set_id("1");
+}
+
+void aca_test_create_default_subnet_state(SubnetState *new_subnet_states)
+{
+  new_subnet_states->set_operation_type(OperationType::INFO);
+
+  SubnetConfiguration *SubnetConiguration_builder =
+          new_subnet_states->mutable_configuration();
+  SubnetConiguration_builder->set_revision_number(1);
+  SubnetConiguration_builder->set_project_id(project_id);
+  SubnetConiguration_builder->set_vpc_id(vpc_id_1);
+  SubnetConiguration_builder->set_id(subnet_id_1);
+  SubnetConiguration_builder->set_cidr("10.0.0.0/24");
+  SubnetConiguration_builder->set_tunnel_id(20);
+
+  auto *subnetConfig_GatewayBuilder(new SubnetConfiguration_Gateway);
+  subnetConfig_GatewayBuilder->set_ip_address(subnet1_gw_ip);
+  subnetConfig_GatewayBuilder->set_mac_address(subnet1_gw_mac);
+  SubnetConiguration_builder->set_allocated_gateway(subnetConfig_GatewayBuilder);
+}
+
+void aca_test_create_default_router_goal_state(GoalState *goalState_builder)
+{
+  RouterState *new_router_states = goalState_builder->add_router_states();
+  SubnetState *new_subnet_states1 = goalState_builder->add_subnet_states();
+  SubnetState *new_subnet_states2 = goalState_builder->add_subnet_states();
+
+  new_router_states->set_operation_type(OperationType::CREATE);
+
+  // fill in router state structs
+  RouterConfiguration *RouterConfiguration_builder =
+          new_router_states->mutable_configuration();
+  RouterConfiguration_builder->set_revision_number(1);
+
+  RouterConfiguration_builder->set_id("router_id1");
+  RouterConfiguration_builder->set_host_dvr_mac_address("fa:16:3e:d7:f2:02");
+
+  auto *RouterConfiguration_SubnetRoutingTable_builder1 =
+          RouterConfiguration_builder->add_subnet_routing_tables();
+  RouterConfiguration_SubnetRoutingTable_builder1->set_subnet_id(subnet_id_1);
+  auto *RouterConfiguration_SubnetRoutingRule_builder1 =
+          RouterConfiguration_SubnetRoutingTable_builder1->add_routing_rules();
+  RouterConfiguration_SubnetRoutingRule_builder1->set_operation_type(OperationType::CREATE);
+  RouterConfiguration_SubnetRoutingRule_builder1->set_id("12345");
+  RouterConfiguration_SubnetRoutingRule_builder1->set_name("routing_rule_1");
+  RouterConfiguration_SubnetRoutingRule_builder1->set_destination("154.12.42.24/32");
+  RouterConfiguration_SubnetRoutingRule_builder1->set_next_hop_ip("154.12.42.101");
+  auto *routerConfiguration_RoutingRuleExtraInfo_builder1(new RouterConfiguration_RoutingRuleExtraInfo);
+  routerConfiguration_RoutingRuleExtraInfo_builder1->set_destination_type(
+          DestinationType::INTERNET);
+  routerConfiguration_RoutingRuleExtraInfo_builder1->set_next_hop_mac("fa:16:3e:d7:aa:02");
+  RouterConfiguration_SubnetRoutingRule_builder1->set_allocated_routing_rule_extra_info(
+          routerConfiguration_RoutingRuleExtraInfo_builder1);
+
+  auto *RouterConfiguration_SubnetRoutingTable_builder2 =
+          RouterConfiguration_builder->add_subnet_routing_tables();
+  RouterConfiguration_SubnetRoutingTable_builder2->set_subnet_id(subnet_id_2);
+  auto *RouterConfiguration_SubnetRoutingRule_builder2 =
+          RouterConfiguration_SubnetRoutingTable_builder2->add_routing_rules();
+  RouterConfiguration_SubnetRoutingRule_builder2->set_operation_type(OperationType::UPDATE);
+  RouterConfiguration_SubnetRoutingRule_builder2->set_id("23456");
+  RouterConfiguration_SubnetRoutingRule_builder2->set_name("routing_rule_2");
+  RouterConfiguration_SubnetRoutingRule_builder2->set_destination("154.12.54.24/32");
+  RouterConfiguration_SubnetRoutingRule_builder2->set_next_hop_ip("154.12.54.101");
+  auto *routerConfiguration_RoutingRuleExtraInfo_builder2(new RouterConfiguration_RoutingRuleExtraInfo);
+  routerConfiguration_RoutingRuleExtraInfo_builder2->set_destination_type(DestinationType::VPC_GW);
+  routerConfiguration_RoutingRuleExtraInfo_builder2->set_next_hop_mac("fa:16:3e:d7:bb:02");
+  RouterConfiguration_SubnetRoutingRule_builder2->set_allocated_routing_rule_extra_info(
+          routerConfiguration_RoutingRuleExtraInfo_builder2);
+
+  // fill in subnet state1 structs
+  aca_test_create_default_subnet_state(new_subnet_states1);
+
+  // fill in subnet state2 structs
+  new_subnet_states2->set_operation_type(OperationType::INFO);
+
+  SubnetConfiguration *SubnetConiguration_builder2 =
+          new_subnet_states2->mutable_configuration();
+  SubnetConiguration_builder2->set_revision_number(1);
+  SubnetConiguration_builder2->set_project_id(project_id);
+  SubnetConiguration_builder2->set_vpc_id(vpc_id_2);
+  SubnetConiguration_builder2->set_id(subnet_id_2);
+  SubnetConiguration_builder2->set_cidr("10.10.1.0/24");
+  SubnetConiguration_builder2->set_tunnel_id(30);
+
+  auto *subnetConfig_GatewayBuilder2(new SubnetConfiguration_Gateway);
+  subnetConfig_GatewayBuilder2->set_ip_address(subnet2_gw_ip);
+  subnetConfig_GatewayBuilder2->set_mac_address(subnet2_gw_mac);
+  SubnetConiguration_builder2->set_allocated_gateway(subnetConfig_GatewayBuilder2);
+}
+
+void aca_test_1_neighbor_CREATE_DELETE(NeighborType input_neighbor_type)
+{
+  ulong not_care_culminative_time = 0;
+  string cmd_string;
+  int overall_rc;
+
+  aca_test_reset_environment();
+
+  GoalState GoalState_builder;
+
+  if (input_neighbor_type == NeighborType::L3) {
+    aca_test_create_default_router_goal_state(&GoalState_builder);
+  } else {
+    // fill in subnet state structs for L2 path only
+    // because the L3 path above already added it
+    SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
+    aca_test_create_default_subnet_state(new_subnet_states);
+  }
+
+  NeighborState *new_neighbor_states = GoalState_builder.add_neighbor_states();
+
+  new_neighbor_states->set_operation_type(OperationType::CREATE);
+
+  // fill in neighbor state structs
+  NeighborConfiguration *NeighborConfiguration_builder =
+          new_neighbor_states->mutable_configuration();
+  NeighborConfiguration_builder->set_revision_number(1);
+
+  NeighborConfiguration_builder->set_project_id(project_id);
+  NeighborConfiguration_builder->set_vpc_id(vpc_id_1);
+  NeighborConfiguration_builder->set_id(port_id_3);
+  NeighborConfiguration_builder->set_mac_address(vmac_address_3);
+  NeighborConfiguration_builder->set_host_ip_address("172.17.111.222");
+
+  NeighborConfiguration_FixedIp *FixedIp_builder =
+          NeighborConfiguration_builder->add_fixed_ips();
+  FixedIp_builder->set_neighbor_type(input_neighbor_type);
+  FixedIp_builder->set_subnet_id(subnet_id_1);
+  FixedIp_builder->set_ip_address(vip_address_3);
+
+  GoalStateOperationReply gsOperationalReply;
+
+  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
+          GoalState_builder, gsOperationalReply);
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+
+  string outport_name = aca_get_outport_name(vxlan_type, "172.17.111.222");
+
+  // check if the outport has been created on br-tun
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          " list-ports br-tun | grep " + outport_name, not_care_culminative_time, overall_rc);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // delete neighbor info
+  new_neighbor_states->set_operation_type(OperationType::DELETE);
+  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
+          GoalState_builder, gsOperationalReply);
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+
+  // check if the outport has been deleted on br-tun
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          " list-ports br-tun | grep " + outport_name, not_care_culminative_time, overall_rc);
+  EXPECT_NE(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // clean up
+
+  // free the allocated configurations since we are done with it now
+  new_neighbor_states->clear_configuration();
+}
+
+void aca_test_1_port_CREATE_plus_neighbor_CREATE(NeighborType input_neighbor_type)
+{
+  ulong not_care_culminative_time = 0;
+  string cmd_string;
+  int overall_rc;
+
+  aca_test_reset_environment();
+
+  GoalState GoalState_builder;
+
+  if (input_neighbor_type == NeighborType::L3) {
+    aca_test_create_default_router_goal_state(&GoalState_builder);
+  } else {
+    // fill in subnet state structs for L2 path only
+    // because the L3 path above already added it
+    SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
+    aca_test_create_default_subnet_state(new_subnet_states);
+  }
+
+  PortState *new_port_states = GoalState_builder.add_port_states();
+
+  // fill in port state structs
+  aca_test_create_default_port_state(new_port_states);
+
+  // add a new neighbor state with CREATE
+  NeighborState *new_neighbor_states = GoalState_builder.add_neighbor_states();
+  new_neighbor_states->set_operation_type(OperationType::CREATE);
+
+  // fill in neighbor state structs
+  NeighborConfiguration *NeighborConfiguration_builder =
+          new_neighbor_states->mutable_configuration();
+  NeighborConfiguration_builder->set_revision_number(1);
+
+  NeighborConfiguration_builder->set_project_id(project_id);
+  NeighborConfiguration_builder->set_vpc_id(vpc_id_1);
+  NeighborConfiguration_builder->set_id(port_id_3);
+  NeighborConfiguration_builder->set_mac_address(vmac_address_3);
+  NeighborConfiguration_builder->set_host_ip_address("172.17.111.222");
+
+  NeighborConfiguration_FixedIp *FixedIp_builder =
+          NeighborConfiguration_builder->add_fixed_ips();
+  FixedIp_builder->set_neighbor_type(input_neighbor_type);
+  FixedIp_builder->set_subnet_id(subnet_id_1);
+  FixedIp_builder->set_ip_address(vip_address_3);
+
+  // set demo mode
+  bool previous_demo_mode = g_demo_mode;
+  g_demo_mode = true;
+
+  // configure the whole goal state in demo mode
+  GoalStateOperationReply gsOperationalReply;
+
+  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
+          GoalState_builder, gsOperationalReply);
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+
+  // restore demo mode
+  g_demo_mode = previous_demo_mode;
+
+  // check to ensure the port 1 is created and setup correctly
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "get Interface " + port_name_1 + " ofport", not_care_culminative_time, overall_rc);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  string outport_name = aca_get_outport_name(vxlan_type, "172.17.111.222");
+
+  // check if the outport has been created on br-tun
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          " list-ports br-tun | grep " + outport_name, not_care_culminative_time, overall_rc);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+
+  // clean up
+
+  // free the allocated configurations since we are done with it now
+  new_port_states->clear_configuration();
+  new_neighbor_states->clear_configuration();
+}
+
+void aca_test_10_neighbor_CREATE(NeighborType input_neighbor_type)
+{
+  string port_name_postfix = "-2222-3333-4444-555555555555";
+  string neighbor_id_postfix = "-baad-f00d-4444-555555555555";
+  string ip_address_prefix = "10.0.0.";
+  string remote_ip_address_prefix = "123.0.0.";
+  int overall_rc;
+
+  aca_test_reset_environment();
+
+  GoalState GoalState_builder;
+  NeighborState *new_neighbor_states;
+
+  if (input_neighbor_type == NeighborType::L3) {
+    aca_test_create_default_router_goal_state(&GoalState_builder);
+  } else {
+    // fill in subnet state structs for L2 path only
+    // because the L3 path above already added it
+    SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
+    aca_test_create_default_subnet_state(new_subnet_states);
+  }
+
+  const int NEIGHBORS_TO_CREATE = 10;
+
+  for (int i = 0; i < NEIGHBORS_TO_CREATE; i++) {
+    string i_string = std::to_string(i);
+    string neighbor_id = i_string + neighbor_id_postfix;
+    string port_name = i_string + port_name_postfix;
+
+    new_neighbor_states = GoalState_builder.add_neighbor_states();
+    new_neighbor_states->set_operation_type(OperationType::CREATE);
+
+    NeighborConfiguration *NeighborConfiguration_builder =
+            new_neighbor_states->mutable_configuration();
+    NeighborConfiguration_builder->set_revision_number(1);
+
+    NeighborConfiguration_builder->set_project_id(project_id);
+    NeighborConfiguration_builder->set_vpc_id("1b08a5bc-b718-11ea-b3de-111122223333");
+    NeighborConfiguration_builder->set_id(neighbor_id);
+    NeighborConfiguration_builder->set_name(port_name);
+    NeighborConfiguration_builder->set_mac_address(vmac_address_1);
+    NeighborConfiguration_builder->set_host_ip_address(remote_ip_address_prefix + i_string);
+
+    NeighborConfiguration_FixedIp *FixedIp_builder =
+            NeighborConfiguration_builder->add_fixed_ips();
+    FixedIp_builder->set_neighbor_type(input_neighbor_type);
+    FixedIp_builder->set_subnet_id(subnet_id_1);
+    FixedIp_builder->set_ip_address(ip_address_prefix + i_string);
+  }
+
+  bool previous_demo_mode = g_demo_mode;
+  g_demo_mode = false;
+
+  GoalStateOperationReply gsOperationReply;
+  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
+          GoalState_builder, gsOperationReply);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+
+  g_demo_mode = previous_demo_mode;
+
+  // calculate the average latency
+  ulong total_neighbor_create_time = 0;
+
+  for (int i = 0; i < NEIGHBORS_TO_CREATE; i++) {
+    ACA_LOG_DEBUG("Neighbor State(%d) took: %u nanoseconds or %u milliseconds\n",
+                  i, gsOperationReply.operation_statuses(i).state_elapse_time(),
+                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000000);
+
+    total_neighbor_create_time +=
+            gsOperationReply.operation_statuses(i).state_elapse_time();
+  }
+
+  ulong average_neighbor_create_time = total_neighbor_create_time / NEIGHBORS_TO_CREATE;
+
+  ACA_LOG_INFO("Average NeighborType: %d Create of %d took: %lu nanoseconds or %lu milliseconds\n",
+               input_neighbor_type, NEIGHBORS_TO_CREATE, average_neighbor_create_time,
+               average_neighbor_create_time / 1000000);
+
+  ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u nanoseconds or %u milliseconds\n",
+               gsOperationReply.message_total_operation_time(),
+               gsOperationReply.message_total_operation_time() / 1000000);
+}

--- a/test/gtest/aca_test_ovs_util.cpp
+++ b/test/gtest/aca_test_ovs_util.cpp
@@ -27,11 +27,11 @@
 
 using namespace std;
 using namespace alcor::schema;
+using namespace aca_comm_manager;
+using namespace aca_net_config;
 using namespace aca_vlan_manager;
 using namespace aca_ovs_l2_programmer;
 using namespace aca_ovs_l3_programmer;
-using aca_comm_manager::Aca_Comm_Manager;
-using aca_net_config::Aca_Net_Config;
 
 string project_id = "99d9d709-8478-4b46-9f3f-000000000000";
 string vpc_id_1 = "1b08a5bc-b718-11ea-b3de-111111111111";


### PR DESCRIPTION
This PR added the ability to delete a port configuration on host. The change added:

1. support for port delete
1. support for L2 neighbor delete
1. support for L3 neighbor delete
1. test case for the above and confirm with traffic
1. test refactoring for reuse and clean up
1. new test cases of L3 neighbor

Also fixes:futurewei-cloud/alcor#103