### PR TITLE
change _vpcs_table hashtable to use tunnel ID as key and added metric data points

### DIFF
--- a/docs/logs/perf_X_neighbors_physical.log
+++ b/docs/logs/perf_X_neighbors_physical.log
@@ -1,0 +1,74 @@
+[***1 port + 1 neighbor***]
+[METRICS] Elapsed time for message total operation took: 49630 microseconds or 49 milliseconds
+Number: 0 Resource Type: 2 with id: 01111111-b718-11ea-b3de-111111111111 took: 16511 microseconds or 16 milliseconds
+Number: 1 Resource Type: 3 with id: 0-baad-f00d-4444-555555555555 took: 20118 microseconds or 20 milliseconds
+Average port + neighbor states with NeighborType: 0 Create of 1 took: 36629 microseconds or 36 milliseconds
+[TEST METRICS] Elapsed time for message total operation took: 49630 microseconds or 49 milliseconds
+
+g_total_execute_system_time = 1624646 microseconds or 1624 milliseconds
+g_total_execute_ovsdb_time = 1574627 microseconds or 1574 milliseconds
+g_total_execute_openflow_time = 43941 microseconds or 43 milliseconds
+g_total_vpcs_table_mutex_time = 19927 microseconds or 19 milliseconds
+g_total_update_GS_time = 49630 microseconds or 49 milliseconds
+
+[***1 port + 10 neighbor***]
+[METRICS] Elapsed time for message total operation took: 180251 microseconds or 180 milliseconds
+Number: 0 Resource Type: 2 with id: 01111111-b718-11ea-b3de-111111111111 took: 16074 microseconds or 16 milliseconds
+Number: 1 Resource Type: 3 with id: 0-baad-f00d-4444-555555555555 took: 19750 microseconds or 19 milliseconds
+Number: 2 Resource Type: 3 with id: 2-baad-f00d-4444-555555555555 took: 32360 microseconds or 32 milliseconds
+Number: 3 Resource Type: 3 with id: 5-baad-f00d-4444-555555555555 took: 44934 microseconds or 44 milliseconds
+Number: 4 Resource Type: 3 with id: 1-baad-f00d-4444-555555555555 took: 61474 microseconds or 61 milliseconds
+Number: 5 Resource Type: 3 with id: 4-baad-f00d-4444-555555555555 took: 74408 microseconds or 74 milliseconds
+Number: 6 Resource Type: 3 with id: 6-baad-f00d-4444-555555555555 took: 88203 microseconds or 88 milliseconds
+Number: 7 Resource Type: 3 with id: 7-baad-f00d-4444-555555555555 took: 102898 microseconds or 102 milliseconds
+Number: 8 Resource Type: 3 with id: 9-baad-f00d-4444-555555555555 took: 116433 microseconds or 116 milliseconds
+Number: 9 Resource Type: 3 with id: 3-baad-f00d-4444-555555555555 took: 134354 microseconds or 134 milliseconds
+Number: 10 Resource Type: 3 with id: 8-baad-f00d-4444-555555555555 took: 146685 microseconds or 146 milliseconds
+Average port + neighbor states with NeighborType: 0 Create of 10 took: 83757 microseconds or 83 milliseconds
+[TEST METRICS] Elapsed time for message total operation took: 180251 microseconds or 180 milliseconds
+
+g_total_execute_system_time = 1786438 microseconds or 1786 milliseconds
+g_total_execute_ovsdb_time = 1639159 microseconds or 1639 milliseconds
+g_total_execute_openflow_time = 115180 microseconds or 115 milliseconds
+g_total_vpcs_table_mutex_time = 789915 microseconds or 789 milliseconds
+g_total_update_GS_time = 180251 microseconds or 180 milliseconds
+
+[***1 port + 100 neighbor***]
+Number: 91 Resource Type: 3 with id: 60-baad-f00d-4444-555555555555 took: 2054718 microseconds or 2054 milliseconds
+Number: 92 Resource Type: 3 with id: 65-baad-f00d-4444-555555555555 took: 2076883 microseconds or 2076 milliseconds
+Number: 93 Resource Type: 3 with id: 12-baad-f00d-4444-555555555555 took: 2138046 microseconds or 2138 milliseconds
+Number: 94 Resource Type: 3 with id: 75-baad-f00d-4444-555555555555 took: 2119864 microseconds or 2119 milliseconds
+Number: 95 Resource Type: 3 with id: 78-baad-f00d-4444-555555555555 took: 2140532 microseconds or 2140 milliseconds
+Number: 96 Resource Type: 3 with id: 83-baad-f00d-4444-555555555555 took: 2161342 microseconds or 2161 milliseconds
+Number: 97 Resource Type: 3 with id: 86-baad-f00d-4444-555555555555 took: 2183843 microseconds or 2183 milliseconds
+Number: 98 Resource Type: 3 with id: 89-baad-f00d-4444-555555555555 took: 2206294 microseconds or 2206 milliseconds
+Number: 99 Resource Type: 3 with id: 92-baad-f00d-4444-555555555555 took: 2227374 microseconds or 2227 milliseconds
+Number: 100 Resource Type: 3 with id: 99-baad-f00d-4444-555555555555 took: 2248690 microseconds or 2248 milliseconds
+Average port + neighbor states with NeighborType: 0 Create of 100 took: 1084776 microseconds or 1084 milliseconds
+
+g_total_execute_system_time = 4279174 microseconds or 4279 milliseconds
+g_total_execute_ovsdb_time = 2727001 microseconds or 2727 milliseconds
+g_total_execute_openflow_time = 1153682 microseconds or 1153 milliseconds
+g_total_vpcs_table_mutex_time = 107963016 microseconds or 107963 milliseconds
+g_total_update_GS_time = 2356041 microseconds or 2356 milliseconds
+
+
+[***1 port + 1000 neighbor***]
+Number: 991 Resource Type: 3 with id: 223-baad-f00d-4444-555555555555 took: 89461798 microseconds or 89461 milliseconds
+Number: 992 Resource Type: 3 with id: 947-baad-f00d-4444-555555555555 took: 86379959 microseconds or 86379 milliseconds
+Number: 993 Resource Type: 3 with id: 951-baad-f00d-4444-555555555555 took: 86482207 microseconds or 86482 milliseconds
+Number: 994 Resource Type: 3 with id: 962-baad-f00d-4444-555555555555 took: 86554818 microseconds or 86554 milliseconds
+Number: 995 Resource Type: 3 with id: 964-baad-f00d-4444-555555555555 took: 86649784 microseconds or 86649 milliseconds
+Number: 996 Resource Type: 3 with id: 972-baad-f00d-4444-555555555555 took: 86743135 microseconds or 86743 milliseconds
+Number: 997 Resource Type: 3 with id: 977-baad-f00d-4444-555555555555 took: 86844267 microseconds or 86844 milliseconds
+Number: 998 Resource Type: 3 with id: 982-baad-f00d-4444-555555555555 took: 86955458 microseconds or 86955 milliseconds
+Number: 999 Resource Type: 3 with id: 994-baad-f00d-4444-555555555555 took: 87006833 microseconds or 87006 milliseconds
+Number: 1000 Resource Type: 3 with id: 999-baad-f00d-4444-555555555555 took: 87105158 microseconds or 87105 milliseconds
+Average port + neighbor states with NeighborType: 0 Create of 1000 took: 35778077 microseconds or 35778 milliseconds
+[TEST METRICS] Elapsed time for message total operation took: 91049082 microseconds or 91049 milliseconds
+
+g_total_execute_system_time = 102768246 microseconds or 102768 milliseconds
+g_total_execute_ovsdb_time = 54702288 microseconds or 54702 milliseconds
+g_total_execute_openflow_time = 35805915 microseconds or 35805 milliseconds
+g_total_vpcs_table_mutex_time = 35762718929 microseconds or 35762718 milliseconds
+g_total_update_GS_time = 91049082 microseconds or 91049 milliseconds

--- a/include/aca_config.h
+++ b/include/aca_config.h
@@ -25,4 +25,6 @@
 
 #define DHCP_MSG_OPTS_DNS_LENGTH (5) //max 5 dns address
 
+#define DEFAULT_MTU 9000
+
 #endif // #ifndef ACA_CONFIG_H

--- a/include/aca_ovs_l2_programmer.h
+++ b/include/aca_ovs_l2_programmer.h
@@ -42,7 +42,7 @@ class ACA_OVS_L2_Programmer {
                                    const std::string remote_host_ip,
                                    uint tunnel_id, ulong &culminative_time);
 
-  int delete_l2_neighbor(const std::string neighbor_id, const std::string vpc_id,
+  int delete_l2_neighbor(const std::string neighbor_id, uint tunnel_id,
                          const std::string outport_name, ulong &culminative_time);
 
   void execute_ovsdb_command(const std::string cmd_string,

--- a/include/aca_util.h
+++ b/include/aca_util.h
@@ -35,6 +35,7 @@
 #define MAX_VALID_VLAN_ID 4094
 
 #define cast_to_nanoseconds(x) chrono::duration_cast<chrono::nanoseconds>(x)
+#define cast_to_microseconds(x) chrono::duration_cast<chrono::microseconds>(x)
 
 static inline const char *aca_get_operation_string(alcor::schema::OperationType operation)
 {
@@ -197,7 +198,8 @@ static inline bool aca_is_port_on_same_host(const std::string hosting_port_ip)
   return (rc == EXIT_SUCCESS);
 }
 
-static inline string aca_convert_cidr_to_netmask(const std::string cidr) {
+static inline string aca_convert_cidr_to_netmask(const std::string cidr)
+{
   if (cidr.empty()) {
     throw std::invalid_argument("cidr is empty");
   }
@@ -210,7 +212,7 @@ static inline string aca_convert_cidr_to_netmask(const std::string cidr) {
 
   int netmask_num = std::stoi(cidr.substr(slash_pos + 1));
   string netmask = "";
-  bool over = false; // mark whether handle all netmask_num 
+  bool over = false; // mark whether handle all netmask_num
   for (int i = 1; i < 5; i++) {
     if (over) {
       // if overed the remain is 0.
@@ -222,19 +224,20 @@ static inline string aca_convert_cidr_to_netmask(const std::string cidr) {
       // before fixed is 255
       netmask += "255.";
     } else {
-      over = true; 
+      over = true;
       int tmp = 0;
       // dynamic netmask handle
       for (int m = 1; m < netmask_num % 8 + 1; m++) {
         tmp += 1 << (8 - m);
-      }  
+      }
       netmask += std::to_string(tmp) + ".";
     }
   }
   return netmask.substr(0, netmask.size() - 1);
 }
 
-static inline long ip4tol(const string ip) {
+static inline long ip4tol(const string ip)
+{
   struct sockaddr_in sa;
   if (inet_pton(AF_INET, ip.c_str(), &(sa.sin_addr)) != 1) {
     throw std::invalid_argument("Virtual ipv4 address is not in the expect format");

--- a/include/aca_util.h
+++ b/include/aca_util.h
@@ -36,6 +36,7 @@
 
 #define cast_to_nanoseconds(x) chrono::duration_cast<chrono::nanoseconds>(x)
 #define cast_to_microseconds(x) chrono::duration_cast<chrono::microseconds>(x)
+#define us_to_ms(x) x / 1000 // convert from microseconds to millseconds
 
 static inline const char *aca_get_operation_string(alcor::schema::OperationType operation)
 {

--- a/include/aca_vlan_manager.h
+++ b/include/aca_vlan_manager.h
@@ -34,15 +34,14 @@ namespace aca_vlan_manager
 struct vpc_table_entry {
   uint vlan_id;
 
-  uint32_t tunnel_id;
   // list of ovs_ports names on this host in the same VPC to share the same internal vlan_id
   list<string> ovs_ports;
+
   // hashtable of output (e.g. vxlan) tunnel ports to the neighbor host communication
-  // to neighbor port ID mapping in this VPC
-  // unordered_map <outports, list of neighbor port IDs>
+  // hashtable <key: outports string, value: list of neighbor port IDs>
   unordered_map<string, list<string> > outports_neighbors_table;
 
-  uint32_t oam_server_port;
+  uint oam_server_port;
 };
 
 class ACA_Vlan_Manager {
@@ -51,9 +50,7 @@ class ACA_Vlan_Manager {
 
   void clear_all_data();
 
-  uint get_or_create_vlan_id(string vpc_id);
-
-  uint get_or_create_vlan_id(uint32_t tunnel_id);
+  uint get_or_create_vlan_id(uint tunnel_id);
 
   int create_ovs_port(string vpc_id, string ovs_port, uint tunnel_id, ulong &culminative_time);
 
@@ -64,22 +61,17 @@ class ACA_Vlan_Manager {
                               uint tunnel_id, ulong &culminative_time);
 
   // create a neighbor port without specifying vpc_id and neighbor ID
-  int create_neighbor_outport(alcor::schema::NetworkType network_type,
-                                                string remote_host_ip, uint tunnel_id,
-                                                ulong &culminative_time);
+  int create_neighbor_outport(alcor::schema::NetworkType network_type, string remote_host_ip,
+                              uint tunnel_id, ulong &culminative_time);
 
-  int delete_neighbor_outport(string neighbor_id, string vpc_id,
+  int delete_neighbor_outport(string neighbor_id, uint tunnel_id,
                               string outport_name, ulong &culminative_time);
 
-  int get_outports_unsafe(string vpc_id, string &outports);
+  int get_outports_unsafe(uint tunnel_id, string &outports);
 
-  int get_oam_server_port(string vpc_id);
+  uint get_oam_server_port(uint tunnel_id);
 
-  int get_oam_server_port(uint32_t tunnel_id);
-
-  void set_oam_server_port(string vpc_id, uint32_t port_number);
-
-  void set_oam_server_port(uint32_t tunnel_id, uint32_t port_number);
+  void set_oam_server_port(uint tunnel_id, uint port_number);
 
   // compiler will flag error when below is called
   ACA_Vlan_Manager(ACA_Vlan_Manager const &) = delete;
@@ -89,12 +81,13 @@ class ACA_Vlan_Manager {
   ACA_Vlan_Manager(){};
   ~ACA_Vlan_Manager(){};
 
-  unordered_map<string, vpc_table_entry> _vpcs_table;
+  // hashtable <key: tunnel ID, value: vpc_table_entry>
+  unordered_map<uint, vpc_table_entry> _vpcs_table;
 
   // mutex for reading and writing to _vpcs_table
   mutex _vpcs_table_mutex;
 
-  void create_entry_unsafe(string vpc_id);
+  void create_entry_unsafe(uint tunnel_id);
 };
 } // namespace aca_vlan_manager
 #endif // #ifndef ACA_VLAN_MANAGER_H

--- a/src/aca_main.cpp
+++ b/src/aca_main.cpp
@@ -68,22 +68,22 @@ static void aca_cleanup()
 {
   ACA_LOG_DEBUG("g_total_execute_system_time = %lu microseconds or %lu milliseconds\n",
                 g_total_execute_system_time.load(),
-                g_total_execute_system_time.load() / 1000);
+                us_to_ms(g_total_execute_system_time.load()));
 
   ACA_LOG_DEBUG("g_total_execute_ovsdb_time = %lu microseconds or %lu milliseconds\n",
                 g_total_execute_ovsdb_time.load(),
-                g_total_execute_ovsdb_time.load() / 1000);
+                us_to_ms(g_total_execute_ovsdb_time.load()));
 
   ACA_LOG_DEBUG("g_total_execute_openflow_time = %lu microseconds or %lu milliseconds\n",
                 g_total_execute_openflow_time.load(),
-                g_total_execute_openflow_time.load() / 1000);
+                us_to_ms(g_total_execute_openflow_time.load()));
 
   ACA_LOG_DEBUG("g_total_vpcs_table_mutex_time = %lu microseconds or %lu milliseconds\n",
                 g_total_vpcs_table_mutex_time.load(),
-                g_total_vpcs_table_mutex_time.load() / 1000);
+                us_to_ms(g_total_vpcs_table_mutex_time.load()));
 
   ACA_LOG_DEBUG("g_total_update_GS_time = %lu microseconds or %lu milliseconds\n",
-                g_total_update_GS_time.load(), g_total_update_GS_time.load() / 1000);
+                g_total_update_GS_time.load(), us_to_ms(g_total_update_GS_time.load()));
 
   ACA_LOG_INFO("%s", "Program exiting, cleaning up...\n");
 

--- a/src/aca_main.cpp
+++ b/src/aca_main.cpp
@@ -49,19 +49,41 @@ string g_grpc_server_port = EMPTY_STRING;
 string g_ofctl_command = EMPTY_STRING;
 string g_ofctl_target = EMPTY_STRING;
 string g_ofctl_options = EMPTY_STRING;
-std::atomic_ulong g_total_network_configuration_time(0);
+
+// total time for execute_system_command in microseconds
+std::atomic_ulong g_total_execute_system_time(0);
+// total time for execute_ovsdb_command in microseconds
+std::atomic_ulong g_total_execute_ovsdb_time(0);
+// total time for execute_openflow_command in microseconds
+std::atomic_ulong g_total_execute_openflow_time(0);
+// total time for vpcs_table_mutex in microseconds
+std::atomic_ulong g_total_vpcs_table_mutex_time(0);
+// total time for goal state update in microseconds
 std::atomic_ulong g_total_update_GS_time(0);
+
 bool g_demo_mode = false;
 bool g_debug_mode = false;
 
 static void aca_cleanup()
 {
-  ACA_LOG_DEBUG("g_total_network_configuration_time = %lu nanoseconds or %lu milliseconds\n",
-                g_total_network_configuration_time.load(),
-                g_total_network_configuration_time.load() / 1000000);
+  ACA_LOG_DEBUG("g_total_execute_system_time = %lu microseconds or %lu milliseconds\n",
+                g_total_execute_system_time.load(),
+                g_total_execute_system_time.load() / 1000);
 
-  ACA_LOG_DEBUG("g_total_update_GS_time = %lu nanoseconds or %lu milliseconds\n",
-                g_total_update_GS_time.load(), g_total_update_GS_time.load() / 1000000);
+  ACA_LOG_DEBUG("g_total_execute_ovsdb_time = %lu microseconds or %lu milliseconds\n",
+                g_total_execute_ovsdb_time.load(),
+                g_total_execute_ovsdb_time.load() / 1000);
+
+  ACA_LOG_DEBUG("g_total_execute_openflow_time = %lu microseconds or %lu milliseconds\n",
+                g_total_execute_openflow_time.load(),
+                g_total_execute_openflow_time.load() / 1000);
+
+  ACA_LOG_DEBUG("g_total_vpcs_table_mutex_time = %lu microseconds or %lu milliseconds\n",
+                g_total_vpcs_table_mutex_time.load(),
+                g_total_vpcs_table_mutex_time.load() / 1000);
+
+  ACA_LOG_DEBUG("g_total_update_GS_time = %lu microseconds or %lu milliseconds\n",
+                g_total_update_GS_time.load(), g_total_update_GS_time.load() / 1000);
 
   ACA_LOG_INFO("%s", "Program exiting, cleaning up...\n");
 

--- a/src/comm/aca_comm_mgr.cpp
+++ b/src/comm/aca_comm_mgr.cpp
@@ -130,10 +130,10 @@ int Aca_Comm_Manager::update_goal_state(GoalState &goal_state_message,
 
   auto end = chrono::steady_clock::now();
 
-  auto message_total_operation_time = cast_to_nanoseconds(end - start).count();
+  auto message_total_operation_time = cast_to_microseconds(end - start).count();
 
-  ACA_LOG_INFO("[METRICS] Elapsed time for message total operation took: %ld nanoseconds or %ld milliseconds\n",
-               message_total_operation_time, message_total_operation_time / 1000000);
+  ACA_LOG_INFO("[METRICS] Elapsed time for message total operation took: %ld microseconds or %ld milliseconds\n",
+               message_total_operation_time, message_total_operation_time / 1000);
 
   gsOperationReply.set_message_total_operation_time(
           message_total_operation_time + gsOperationReply.message_total_operation_time());

--- a/src/comm/aca_comm_mgr.cpp
+++ b/src/comm/aca_comm_mgr.cpp
@@ -133,7 +133,7 @@ int Aca_Comm_Manager::update_goal_state(GoalState &goal_state_message,
   auto message_total_operation_time = cast_to_microseconds(end - start).count();
 
   ACA_LOG_INFO("[METRICS] Elapsed time for message total operation took: %ld microseconds or %ld milliseconds\n",
-               message_total_operation_time, message_total_operation_time / 1000);
+               message_total_operation_time, us_to_ms(message_total_operation_time));
 
   gsOperationReply.set_message_total_operation_time(
           message_total_operation_time + gsOperationReply.message_total_operation_time());

--- a/src/dhcp/aca_dhcp_state_handler.cpp
+++ b/src/dhcp/aca_dhcp_state_handler.cpp
@@ -99,7 +99,7 @@ int Aca_Dhcp_State_Handler::update_dhcp_state_workitem(const DHCPState current_D
   auto operation_end = chrono::steady_clock::now();
 
   auto operation_total_time =
-          cast_to_nanoseconds(operation_end - operation_start).count();
+          cast_to_microseconds(operation_end - operation_start).count();
 
   aca_goal_state_handler::Aca_Goal_State_Handler::get_instance().add_goal_state_operation_status(
           gsOperationReply, "NA_ID", DHCP, current_DhcpState.operation_type(),

--- a/src/dp_abstraction/aca_dataplane_ovs.cpp
+++ b/src/dp_abstraction/aca_dataplane_ovs.cpp
@@ -444,9 +444,8 @@ int ACA_Dataplane_OVS::update_neighbor_state_workitem(NeighborState current_Neig
                       aca_get_outport_name(found_network_type, host_ip_address);
 
               overall_rc = ACA_OVS_L2_Programmer::get_instance().delete_l2_neighbor(
-                      current_NeighborConfiguration.id(),
-                      current_NeighborConfiguration.vpc_id(), outport_name,
-                      culminative_dataplane_programming_time);
+                      current_NeighborConfiguration.id(), found_tunnel_id,
+                      outport_name, culminative_dataplane_programming_time);
             } else {
               ACA_LOG_ERROR("Invalid neighbor state operation type %d\n",
                             current_NeighborState.operation_type());

--- a/src/dp_abstraction/aca_dataplane_ovs.cpp
+++ b/src/dp_abstraction/aca_dataplane_ovs.cpp
@@ -143,7 +143,7 @@ int ACA_Dataplane_OVS::update_subnet_state_workitem(const SubnetState current_Su
   auto operation_end = chrono::steady_clock::now();
 
   auto operation_total_time =
-          cast_to_nanoseconds(operation_end - operation_start).count();
+          cast_to_microseconds(operation_end - operation_start).count();
 
   aca_goal_state_handler::Aca_Goal_State_Handler::get_instance().add_goal_state_operation_status(
           gsOperationReply, current_SubnetConfiguration.id(), SUBNET,
@@ -307,7 +307,7 @@ EXIT:
   auto operation_end = chrono::steady_clock::now();
 
   auto operation_total_time =
-          cast_to_nanoseconds(operation_end - operation_start).count();
+          cast_to_microseconds(operation_end - operation_start).count();
 
   aca_goal_state_handler::Aca_Goal_State_Handler::get_instance().add_goal_state_operation_status(
           gsOperationReply, current_PortConfiguration.id(), ResourceType::PORT,
@@ -500,7 +500,7 @@ int ACA_Dataplane_OVS::update_neighbor_state_workitem(NeighborState current_Neig
   auto operation_end = chrono::steady_clock::now();
 
   auto operation_total_time =
-          cast_to_nanoseconds(operation_end - operation_start).count();
+          cast_to_microseconds(operation_end - operation_start).count();
 
   aca_goal_state_handler::Aca_Goal_State_Handler::get_instance().add_goal_state_operation_status(
           gsOperationReply, current_NeighborConfiguration.id(),
@@ -557,7 +557,7 @@ int ACA_Dataplane_OVS::update_router_state_workitem(RouterState current_RouterSt
   auto operation_end = chrono::steady_clock::now();
 
   auto operation_total_time =
-          cast_to_nanoseconds(operation_end - operation_start).count();
+          cast_to_microseconds(operation_end - operation_start).count();
 
   aca_goal_state_handler::Aca_Goal_State_Handler::get_instance().add_goal_state_operation_status(
           gsOperationReply, current_RouterConfiguration.id(),

--- a/src/net_config/aca_net_config.cpp
+++ b/src/net_config/aca_net_config.cpp
@@ -14,12 +14,11 @@
 
 #include "aca_log.h"
 #include "aca_util.h"
+#include "aca_config.h"
 #include "aca_net_config.h"
 #include <errno.h>
 
 using namespace std;
-
-static char DEFAULT_MTU[] = "9000";
 
 extern std::atomic_ulong g_total_execute_system_time;
 extern bool g_demo_mode;
@@ -97,7 +96,8 @@ int Aca_Net_Config::setup_peer_device(string peer_name, ulong &culminative_time)
     return rc;
   }
 
-  string cmd_string = "ip link set dev " + peer_name + " up mtu " + DEFAULT_MTU;
+  string cmd_string =
+          "ip link set dev " + peer_name + " up mtu " + std::to_string(DEFAULT_MTU);
 
   return execute_system_command(cmd_string, culminative_time);
 }
@@ -334,7 +334,7 @@ int Aca_Net_Config::execute_system_command(string cmd_string, ulong &culminative
   }
 
   ACA_LOG_DEBUG(" Elapsed time for system command took: %ld microseconds or %ld milliseconds.\n",
-                execute_system_elapse_time, execute_system_elapse_time / 1000);
+                execute_system_elapse_time, us_to_ms(execute_system_elapse_time));
 
   return rc;
 }

--- a/src/net_config/aca_net_config.cpp
+++ b/src/net_config/aca_net_config.cpp
@@ -13,18 +13,15 @@
 // limitations under the License.
 
 #include "aca_log.h"
+#include "aca_util.h"
 #include "aca_net_config.h"
 #include <errno.h>
-#include <stdlib.h>
-#include <string>
-#include <chrono>
-#include <atomic>
 
 using namespace std;
 
 static char DEFAULT_MTU[] = "9000";
 
-extern std::atomic_ulong g_total_network_configuration_time;
+extern std::atomic_ulong g_total_execute_system_time;
 extern bool g_demo_mode;
 
 namespace aca_net_config
@@ -316,20 +313,19 @@ int Aca_Net_Config::execute_system_command(string cmd_string, ulong &culminative
 
   ACA_LOG_INFO("Executing command: %s\n", cmd_string.c_str());
 
-  auto network_configuration_time_start = chrono::steady_clock::now();
+  auto execute_system_time_start = chrono::steady_clock::now();
 
   rc = system(cmd_string.c_str());
 
-  auto network_configuration_time_end = chrono::steady_clock::now();
+  auto execute_system_time_end = chrono::steady_clock::now();
 
-  auto network_configuration_elapse_time =
-          chrono::duration_cast<chrono::nanoseconds>(
-                  network_configuration_time_end - network_configuration_time_start)
+  auto execute_system_elapse_time =
+          cast_to_microseconds(execute_system_time_end - execute_system_time_start)
                   .count();
 
-  culminative_time += network_configuration_elapse_time;
+  culminative_time += execute_system_elapse_time;
 
-  g_total_network_configuration_time += network_configuration_elapse_time;
+  g_total_execute_system_time += execute_system_elapse_time;
 
   if (rc == EXIT_SUCCESS) {
     ACA_LOG_INFO("%s", "Command succeeded!\n");
@@ -337,9 +333,8 @@ int Aca_Net_Config::execute_system_command(string cmd_string, ulong &culminative
     ACA_LOG_DEBUG("Command failed!!! rc: %d\n", rc);
   }
 
-  ACA_LOG_DEBUG(" Elapsed time for system command took: %ld nanoseconds or %ld milliseconds.\n",
-                network_configuration_elapse_time,
-                network_configuration_elapse_time / 1000000);
+  ACA_LOG_DEBUG(" Elapsed time for system command took: %ld microseconds or %ld milliseconds.\n",
+                execute_system_elapse_time, execute_system_elapse_time / 1000);
 
   return rc;
 }

--- a/src/ovs/aca_ovs_l2_programmer.cpp
+++ b/src/ovs/aca_ovs_l2_programmer.cpp
@@ -359,7 +359,7 @@ void ACA_OVS_L2_Programmer::execute_ovsdb_command(const std::string cmd_string,
   g_total_execute_ovsdb_time += ovsdb_client_time_total_time;
 
   ACA_LOG_INFO("Elapsed time for ovsdb client call took: %ld microseconds or %ld milliseconds. rc: %d\n",
-               ovsdb_client_time_total_time, ovsdb_client_time_total_time / 1000, rc);
+               ovsdb_client_time_total_time, us_to_ms(ovsdb_client_time_total_time), rc);
 
   ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::execute_ovsdb_command <--- Exiting, rc = %d\n", rc);
 }
@@ -389,7 +389,7 @@ void ACA_OVS_L2_Programmer::execute_openflow_command(const std::string cmd_strin
 
   ACA_LOG_INFO("Elapsed time for openflow client call took: %ld microseconds or %ld milliseconds. rc: %d\n",
                openflow_client_time_total_time,
-               openflow_client_time_total_time / 1000, rc);
+               us_to_ms(openflow_client_time_total_time), rc);
 
   ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::execute_openflow_command <--- Exiting, rc = %d\n", rc);
 }

--- a/src/ovs/aca_ovs_l2_programmer.cpp
+++ b/src/ovs/aca_ovs_l2_programmer.cpp
@@ -28,6 +28,8 @@ using namespace aca_vlan_manager;
 // mutex for reading and writing to ovs bridges (br-int and br-tun) setups
 mutex setup_ovs_bridges_mutex;
 
+extern std::atomic_ulong g_total_execute_ovsdb_time;
+extern std::atomic_ulong g_total_execute_openflow_time;
 extern bool g_demo_mode;
 
 namespace aca_ovs_l2_programmer
@@ -350,12 +352,14 @@ void ACA_OVS_L2_Programmer::execute_ovsdb_command(const std::string cmd_string,
   auto ovsdb_client_end = chrono::steady_clock::now();
 
   auto ovsdb_client_time_total_time =
-          cast_to_nanoseconds(ovsdb_client_end - ovsdb_client_start).count();
+          cast_to_microseconds(ovsdb_client_end - ovsdb_client_start).count();
 
   culminative_time += ovsdb_client_time_total_time;
 
-  ACA_LOG_INFO("Elapsed time for ovsdb client call took: %ld nanoseconds or %ld milliseconds. rc: %d\n",
-               ovsdb_client_time_total_time, ovsdb_client_time_total_time / 1000000, rc);
+  g_total_execute_ovsdb_time += ovsdb_client_time_total_time;
+
+  ACA_LOG_INFO("Elapsed time for ovsdb client call took: %ld microseconds or %ld milliseconds. rc: %d\n",
+               ovsdb_client_time_total_time, ovsdb_client_time_total_time / 1000, rc);
 
   ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::execute_ovsdb_command <--- Exiting, rc = %d\n", rc);
 }
@@ -377,13 +381,15 @@ void ACA_OVS_L2_Programmer::execute_openflow_command(const std::string cmd_strin
   auto openflow_client_end = chrono::steady_clock::now();
 
   auto openflow_client_time_total_time =
-          cast_to_nanoseconds(openflow_client_end - openflow_client_start).count();
+          cast_to_microseconds(openflow_client_end - openflow_client_start).count();
 
   culminative_time += openflow_client_time_total_time;
 
-  ACA_LOG_INFO("Elapsed time for openflow client call took: %ld nanoseconds or %ld milliseconds. rc: %d\n",
+  g_total_execute_openflow_time += openflow_client_time_total_time;
+
+  ACA_LOG_INFO("Elapsed time for openflow client call took: %ld microseconds or %ld milliseconds. rc: %d\n",
                openflow_client_time_total_time,
-               openflow_client_time_total_time / 1000000, rc);
+               openflow_client_time_total_time / 1000, rc);
 
   ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::execute_openflow_command <--- Exiting, rc = %d\n", rc);
 }

--- a/src/ovs/aca_ovs_l2_programmer.cpp
+++ b/src/ovs/aca_ovs_l2_programmer.cpp
@@ -192,7 +192,7 @@ int ACA_OVS_L2_Programmer::create_port(const string vpc_id, const string port_na
 
   // use vpc_id to query vlan_manager to lookup an existing vpc_id entry to get its
   // internal vlan id or to create a new vpc_id entry to get a new internal vlan id
-  int internal_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(vpc_id);
+  int internal_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(tunnel_id);
 
   ACA_Vlan_Manager::get_instance().create_ovs_port(vpc_id, port_name, tunnel_id, culminative_time);
 
@@ -307,7 +307,7 @@ int ACA_OVS_L2_Programmer::create_or_update_l2_neighbor(
   return overall_rc;
 }
 
-int ACA_OVS_L2_Programmer::delete_l2_neighbor(const string neighbor_id, const string vpc_id,
+int ACA_OVS_L2_Programmer::delete_l2_neighbor(const string neighbor_id, uint tunnel_id,
                                               const string outport_name, ulong &culminative_time)
 {
   ACA_LOG_DEBUG("%s", "ACA_OVS_L2_Programmer::delete_l2_neighbor ---> Entering\n");
@@ -316,8 +316,8 @@ int ACA_OVS_L2_Programmer::delete_l2_neighbor(const string neighbor_id, const st
     throw std::invalid_argument("neighbor_id is empty");
   }
 
-  if (vpc_id.empty()) {
-    throw std::invalid_argument("vpc_id is empty");
+  if (tunnel_id == 0) {
+    throw std::invalid_argument("tunnel_id is 0");
   }
 
   if (outport_name.empty()) {
@@ -325,7 +325,7 @@ int ACA_OVS_L2_Programmer::delete_l2_neighbor(const string neighbor_id, const st
   }
 
   int overall_rc = ACA_Vlan_Manager::get_instance().delete_neighbor_outport(
-          neighbor_id, vpc_id, outport_name, culminative_time);
+          neighbor_id, tunnel_id, outport_name, culminative_time);
 
   ACA_LOG_DEBUG("ACA_OVS_L2_Programmer::delete_l2_neighbor <--- Exiting, overall_rc = %d\n",
                 overall_rc);

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -212,7 +212,7 @@ int ACA_OVS_L3_Programmer::create_or_update_router(RouterConfiguration &current_
           // don't need to handle the gateway_ip and gateway_mac change, because that will
           // require the subnet to remove the gateway port and add in a new one
 
-          source_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(found_vpc_id);
+          source_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(found_tunnel_id);
 
           current_gateway_mac = found_gateway_mac;
           current_gateway_mac.erase(
@@ -409,7 +409,7 @@ int ACA_OVS_L3_Programmer::delete_router(RouterConfiguration &current_RouterConf
     ACA_LOG_DEBUG("Subnet_id entry to delete:%s\n", subnet_entry_to_delete.c_str());
 
     source_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(
-            subnet_it->second.vpc_id);
+            subnet_it->second.tunnel_id);
 
     current_gateway_mac = subnet_it->second.gateway_mac;
     current_gateway_mac.erase(
@@ -534,10 +534,10 @@ int ACA_OVS_L3_Programmer::create_or_update_l3_neighbor(
         ACA_LOG_DEBUG("Found L3 neighbor subnet_id:%s\n ", subnet_it->first.c_str());
 
         source_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(
-                subnet_it->second.vpc_id);
+                subnet_it->second.tunnel_id);
 
         destination_vlan_id =
-                ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(vpc_id);
+                ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(tunnel_id);
 
         // for the first implementation, we will go ahead and program the on demand routing rule here
         // in the future, the programming of the on demand rule will be triggered by the first packet
@@ -639,7 +639,7 @@ int ACA_OVS_L3_Programmer::delete_l3_neighbor(const string neighbor_id, const st
         ACA_LOG_DEBUG("subnet_id:%s\n ", subnet_it->first.c_str());
 
         source_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(
-                subnet_it->second.vpc_id);
+                subnet_it->second.tunnel_id);
 
         // for the first implementation with static routing rules (non on-demand)
         // go ahead to remove it

--- a/src/ovs/aca_vlan_manager.cpp
+++ b/src/ovs/aca_vlan_manager.cpp
@@ -51,7 +51,7 @@ void ACA_Vlan_Manager::clear_all_data()
 
 // unsafe function, needs to be called inside vpc_table_mutex lock
 // this function assumes there is no existing entry for vpc_id
-void ACA_Vlan_Manager::create_entry_unsafe(string vpc_id)
+void ACA_Vlan_Manager::create_entry_unsafe(uint tunnel_id)
 {
   ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::create_entry_unsafe ---> Entering\n");
 
@@ -59,21 +59,21 @@ void ACA_Vlan_Manager::create_entry_unsafe(string vpc_id)
   new_table_entry.vlan_id = current_available_vlan_id.load();
   current_available_vlan_id++;
 
-  _vpcs_table.emplace(vpc_id, new_table_entry);
+  _vpcs_table.emplace(tunnel_id, new_table_entry);
 
   ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::create_entry_unsafe <--- Exiting\n");
 }
 
-uint ACA_Vlan_Manager::get_or_create_vlan_id(string vpc_id)
+uint ACA_Vlan_Manager::get_or_create_vlan_id(uint tunnel_id)
 {
   ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::get_or_create_vlan_id ---> Entering\n");
 
   // -----critical section starts-----
   _vpcs_table_mutex.lock();
-  if (_vpcs_table.find(vpc_id) == _vpcs_table.end()) {
-    create_entry_unsafe(vpc_id);
+  if (_vpcs_table.find(tunnel_id) == _vpcs_table.end()) {
+    create_entry_unsafe(tunnel_id);
   }
-  uint acquired_vlan_id = _vpcs_table[vpc_id].vlan_id;
+  uint acquired_vlan_id = _vpcs_table[tunnel_id].vlan_id;
   _vpcs_table_mutex.unlock();
   // -----critical section ends-----
 
@@ -82,7 +82,7 @@ uint ACA_Vlan_Manager::get_or_create_vlan_id(string vpc_id)
   return acquired_vlan_id;
 }
 
-int ACA_Vlan_Manager::create_ovs_port(string vpc_id, string ovs_port,
+int ACA_Vlan_Manager::create_ovs_port(string /*vpc_id*/, string ovs_port,
                                       uint tunnel_id, ulong &culminative_time)
 {
   int overall_rc = EXIT_SUCCESS;
@@ -91,7 +91,7 @@ int ACA_Vlan_Manager::create_ovs_port(string vpc_id, string ovs_port,
 
   // use vpc_id to query vlan_manager to lookup an existing vpc_id entry to get its
   // internal vlan id
-  int internal_vlan_id = this->get_or_create_vlan_id(vpc_id);
+  int internal_vlan_id = this->get_or_create_vlan_id(tunnel_id);
 
   string cmd_string =
           "add-flow br-tun \"table=4, priority=1,tun_id=" + to_string(tunnel_id) +
@@ -99,17 +99,17 @@ int ACA_Vlan_Manager::create_ovs_port(string vpc_id, string ovs_port,
 
   // -----critical section starts-----
   _vpcs_table_mutex.lock();
-  if (_vpcs_table.find(vpc_id) == _vpcs_table.end()) {
-    create_entry_unsafe(vpc_id);
+  if (_vpcs_table.find(tunnel_id) == _vpcs_table.end()) {
+    create_entry_unsafe(tunnel_id);
   }
   // first port in the VPC will add the below rule:
   // table 4 = incoming vxlan, allow incoming vxlan traffic matching tunnel_id
   // to stamp with internal vlan and deliver to br-int
-  if (_vpcs_table[vpc_id].ovs_ports.empty()) {
+  if (_vpcs_table[tunnel_id].ovs_ports.empty()) {
     ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
             cmd_string, culminative_time, overall_rc);
   }
-  _vpcs_table[vpc_id].ovs_ports.push_back(ovs_port);
+  _vpcs_table[tunnel_id].ovs_ports.push_back(ovs_port);
   _vpcs_table_mutex.unlock();
   // -----critical section ends-----
 
@@ -119,7 +119,7 @@ int ACA_Vlan_Manager::create_ovs_port(string vpc_id, string ovs_port,
 }
 
 // called when a port associated with a vpc on this host is deleted
-int ACA_Vlan_Manager::delete_ovs_port(string vpc_id, string ovs_port,
+int ACA_Vlan_Manager::delete_ovs_port(string /*vpc_id*/, string ovs_port,
                                       uint tunnel_id, ulong &culminative_time)
 {
   int overall_rc = EXIT_SUCCESS;
@@ -128,19 +128,19 @@ int ACA_Vlan_Manager::delete_ovs_port(string vpc_id, string ovs_port,
 
   // use vpc_id to query vlan_manager to lookup an existing vpc_id entry to get its
   // internal vlan id
-  int internal_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(vpc_id);
+  int internal_vlan_id = ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(tunnel_id);
 
   // -----critical section starts-----
   _vpcs_table_mutex.lock();
-  if (_vpcs_table.find(vpc_id) == _vpcs_table.end()) {
-    ACA_LOG_ERROR("vpc_id %s not found in vpc_table\n", vpc_id.c_str());
+  if (_vpcs_table.find(tunnel_id) == _vpcs_table.end()) {
+    ACA_LOG_ERROR("tunnel_id %u not found in vpc_table\n", tunnel_id);
     overall_rc = ENOENT;
   } else {
-    _vpcs_table[vpc_id].ovs_ports.remove(ovs_port);
+    _vpcs_table[tunnel_id].ovs_ports.remove(ovs_port);
     // clean up the vpc_table entry if there is no port assoicated
-    if (_vpcs_table[vpc_id].ovs_ports.empty()) {
-      if (_vpcs_table.erase(vpc_id) == 1) {
-        ACA_LOG_INFO("Successfuly cleaned up entry for vpc_id %s\n", vpc_id.c_str());
+    if (_vpcs_table[tunnel_id].ovs_ports.empty()) {
+      if (_vpcs_table.erase(tunnel_id) == 1) {
+        ACA_LOG_INFO("Successfuly cleaned up entry for tunnel_id %u\n", tunnel_id);
 
         // also delete the rule assoicated with the VPC:
         // table 4 = incoming vxlan, allow incoming vxlan traffic matching tunnel_id
@@ -152,7 +152,7 @@ int ACA_Vlan_Manager::delete_ovs_port(string vpc_id, string ovs_port,
         ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
                 cmd_string, culminative_time, overall_rc);
       } else {
-        ACA_LOG_ERROR("Failed to clean up entry for vpc_id %s\n", vpc_id.c_str());
+        ACA_LOG_ERROR("Failed to clean up entry for tunnel_id %d\n", tunnel_id);
         overall_rc = EXIT_FAILURE;
       }
     }
@@ -165,7 +165,7 @@ int ACA_Vlan_Manager::delete_ovs_port(string vpc_id, string ovs_port,
   return overall_rc;
 } // namespace aca_vlan_manager
 
-int ACA_Vlan_Manager::create_neighbor_outport(string neighbor_id, string vpc_id,
+int ACA_Vlan_Manager::create_neighbor_outport(string neighbor_id, string /*vpc_id*/,
                                               alcor::schema::NetworkType network_type,
                                               string remote_host_ip, uint tunnel_id,
                                               ulong &culminative_time)
@@ -178,23 +178,23 @@ int ACA_Vlan_Manager::create_neighbor_outport(string neighbor_id, string vpc_id,
 
   // use vpc_id to query vlan_manager to lookup an existing vpc_id entry to get its
   // internal vlan id or to create a new vpc_id entry to get a new internal vlan id
-  int internal_vlan_id = this->get_or_create_vlan_id(vpc_id);
+  int internal_vlan_id = this->get_or_create_vlan_id(tunnel_id);
 
   // -----critical section starts-----
   _vpcs_table_mutex.lock();
 
   // if the vpc entry is not there, create it first
-  if (_vpcs_table.find(vpc_id) == _vpcs_table.end()) {
-    create_entry_unsafe(vpc_id);
+  if (_vpcs_table.find(tunnel_id) == _vpcs_table.end()) {
+    create_entry_unsafe(tunnel_id);
   }
 
-  auto current_outports_neighbors_table = _vpcs_table[vpc_id].outports_neighbors_table;
+  auto current_outports_neighbors_table = _vpcs_table[tunnel_id].outports_neighbors_table;
 
   if (current_outports_neighbors_table.find(outport_name) ==
       current_outports_neighbors_table.end()) {
     // outport is not there yet, need to create a new entry
     std::list<string> neighbors(1, neighbor_id);
-    _vpcs_table[vpc_id].outports_neighbors_table.emplace(outport_name, neighbors);
+    _vpcs_table[tunnel_id].outports_neighbors_table.emplace(outport_name, neighbors);
 
     // since this is a new outport, configure OVS and openflow rule
     string cmd_string =
@@ -215,7 +215,7 @@ int ACA_Vlan_Manager::create_neighbor_outport(string neighbor_id, string vpc_id,
 
     if (overall_rc == EXIT_SUCCESS) {
       string full_outport_list;
-      this->get_outports_unsafe(vpc_id, full_outport_list);
+      this->get_outports_unsafe(tunnel_id, full_outport_list);
 
       // match internal vlan based on VPC, output for all outports based on the same
       // tunnel ID (multicast traffic)
@@ -228,7 +228,7 @@ int ACA_Vlan_Manager::create_neighbor_outport(string neighbor_id, string vpc_id,
     }
   } else {
     // else outport is already there, simply insert the neighbor id into outports_neighbors_table
-    _vpcs_table[vpc_id].outports_neighbors_table[outport_name].push_back(neighbor_id);
+    _vpcs_table[tunnel_id].outports_neighbors_table[outport_name].push_back(neighbor_id);
   }
 
   _vpcs_table_mutex.unlock();
@@ -240,7 +240,7 @@ int ACA_Vlan_Manager::create_neighbor_outport(string neighbor_id, string vpc_id,
 }
 
 // called when a L2 neighbor info is deleted
-int ACA_Vlan_Manager::delete_neighbor_outport(string neighbor_id, string vpc_id,
+int ACA_Vlan_Manager::delete_neighbor_outport(string neighbor_id, uint tunnel_id,
                                               string outport_name, ulong &culminative_time)
 {
   ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::delete_neighbor_outport ---> Entering\n");
@@ -248,15 +248,15 @@ int ACA_Vlan_Manager::delete_neighbor_outport(string neighbor_id, string vpc_id,
   int overall_rc = EXIT_SUCCESS;
   string cmd_string;
 
-  int internal_vlan_id = this->get_or_create_vlan_id(vpc_id);
+  int internal_vlan_id = this->get_or_create_vlan_id(tunnel_id);
 
   // -----critical section starts-----
   _vpcs_table_mutex.lock();
-  if (_vpcs_table.find(vpc_id) == _vpcs_table.end()) {
-    ACA_LOG_ERROR("vpc_id %s not found in vpc_table\n", vpc_id.c_str());
+  if (_vpcs_table.find(tunnel_id) == _vpcs_table.end()) {
+    ACA_LOG_ERROR("tunnel_id %u not found in vpc_table\n", tunnel_id);
     overall_rc = ENOENT;
   } else {
-    auto current_outports_neighbors_table = _vpcs_table[vpc_id].outports_neighbors_table;
+    auto current_outports_neighbors_table = _vpcs_table[tunnel_id].outports_neighbors_table;
 
     if (current_outports_neighbors_table.find(outport_name) !=
         current_outports_neighbors_table.end()) {
@@ -274,7 +274,7 @@ int ACA_Vlan_Manager::delete_neighbor_outport(string neighbor_id, string vpc_id,
                 cmd_string, culminative_time, overall_rc);
 
         // delete the outports_neighbors_table[outport_name] entry
-        if (_vpcs_table[vpc_id].outports_neighbors_table.erase(outport_name) != 1) {
+        if (_vpcs_table[tunnel_id].outports_neighbors_table.erase(outport_name) != 1) {
           ACA_LOG_ERROR("Failed to clean up entry for outport_name: %s\n",
                         outport_name.c_str());
           overall_rc = EXIT_FAILURE;
@@ -328,19 +328,19 @@ int ACA_Vlan_Manager::delete_neighbor_outport(string neighbor_id, string vpc_id,
 }
 
 // unsafe function, needs to be called under vpc_table_mutex lock
-int ACA_Vlan_Manager::get_outports_unsafe(string vpc_id, string &outports)
+int ACA_Vlan_Manager::get_outports_unsafe(uint tunnel_id, string &outports)
 {
-  ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::get_outports ---> Entering\n");
+  ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::get_outports_unsafe ---> Entering\n");
 
   int overall_rc;
   static string OUTPUT = "output:\"";
 
-  if (_vpcs_table.find(vpc_id) == _vpcs_table.end()) {
-    ACA_LOG_ERROR("vpc_id %s not found in vpc_table\n", vpc_id.c_str());
+  if (_vpcs_table.find(tunnel_id) == _vpcs_table.end()) {
+    ACA_LOG_ERROR("tunnel_id %u not found in vpc_table\n", tunnel_id);
     overall_rc = ENOENT;
   } else {
     outports.clear();
-    auto current_outports_neighbors_table = _vpcs_table[vpc_id].outports_neighbors_table;
+    auto current_outports_neighbors_table = _vpcs_table[tunnel_id].outports_neighbors_table;
 
     for (auto it : current_outports_neighbors_table) {
       if (outports.empty()) {
@@ -352,75 +352,48 @@ int ACA_Vlan_Manager::get_outports_unsafe(string vpc_id, string &outports)
     overall_rc = EXIT_SUCCESS;
   }
 
-  ACA_LOG_DEBUG("ACA_Vlan_Manager::get_outports <--- Exiting, overall_rc = %d\n", overall_rc);
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::get_outports_unsafe <--- Exiting, overall_rc = %d\n",
+                overall_rc);
 
   return overall_rc;
 }
 
-//query oam_port with vpc_id
-int ACA_Vlan_Manager::get_oam_server_port(string vpc_id)
+// query oam_port with tunnel_id
+uint ACA_Vlan_Manager::get_oam_server_port(uint tunnel_id)
 {
   ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::get_oam_server_port ---> Entering\n");
 
-  int overall_rc;
-  uint32_t port_number;
+  uint port_number;
+
   // -----critical section starts-----
   _vpcs_table_mutex.lock();
-  if (_vpcs_table.find(vpc_id) == _vpcs_table.end()) {
-    ACA_LOG_ERROR("vpc_id %s not find in vpc_table\n", vpc_id.c_str());
-    // If the vpc cannot be found, set the port number to 0.
+  if (_vpcs_table.find(tunnel_id) == _vpcs_table.end()) {
+    ACA_LOG_ERROR("tunnel_id %u not find in vpc_table\n", tunnel_id);
+    // If the tunnel_id cannot be found, set the port number to 0.
     port_number = 0;
-    overall_rc = ENOENT;
   } else {
-    port_number = _vpcs_table[vpc_id].oam_server_port;
-    overall_rc = EXIT_SUCCESS;
+    port_number = _vpcs_table[tunnel_id].oam_server_port;
   }
   _vpcs_table_mutex.unlock();
   // -----critical section ends-----
-  ACA_LOG_DEBUG("ACA_Vlan_Manager::get_oam_server_port <--- Exiting, overall_rc = %d\n",
-                overall_rc);
 
-  return port_number;
-}
-
-//query oam_port with tunnel_id
-int ACA_Vlan_Manager::get_oam_server_port(uint32_t tunnel_id)
-{
-  ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::get_oam_server_port ---> Entering\n");
-
-  uint32_t port_number = 0;
-  int overall_rc = ENOENT;
-  // -----critical section starts-----
-  _vpcs_table_mutex.lock();
-  unordered_map<string, vpc_table_entry>::iterator iter;
-  for (iter = _vpcs_table.begin(); iter != _vpcs_table.end(); iter++) {
-    vpc_table_entry entry = iter->second;
-    if (entry.tunnel_id == tunnel_id) {
-      port_number = entry.oam_server_port;
-      overall_rc = EXIT_SUCCESS;
-      break;
-    }
-  }
-
-  _vpcs_table_mutex.unlock();
-  // -----critical section ends-----
-  ACA_LOG_DEBUG("ACA_Vlan_Manager::get_oam_server_port <--- Exiting, overall_rc = %d\n",
-                overall_rc);
+  ACA_LOG_DEBUG("ACA_Vlan_Manager::get_oam_server_port <--- Exiting, port_number=%u\n",
+                port_number);
 
   return port_number;
 }
 
 // Bind oam_server_port to vpc
-void ACA_Vlan_Manager::set_oam_server_port(string vpc_id, uint32_t port_number)
+void ACA_Vlan_Manager::set_oam_server_port(uint tunnel_id, uint port_number)
 {
   ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::set_oam_server_port ---> Entering\n");
 
   // -----critical section starts-----
   _vpcs_table_mutex.lock();
-  if (_vpcs_table.find(vpc_id) == _vpcs_table.end()) {
-    create_entry_unsafe(vpc_id);
+  if (_vpcs_table.find(tunnel_id) == _vpcs_table.end()) {
+    create_entry_unsafe(tunnel_id);
   }
-  _vpcs_table[vpc_id].oam_server_port = port_number;
+  _vpcs_table[tunnel_id].oam_server_port = port_number;
   _vpcs_table_mutex.unlock();
   // -----critical section ends-----
 
@@ -428,23 +401,15 @@ void ACA_Vlan_Manager::set_oam_server_port(string vpc_id, uint32_t port_number)
 }
 
 #ifdef __GNUC__
-#  define UNUSE(x) UNUSE_ ## x __attribute__((__unused__))
+#define UNUSE(x) UNUSE_##x __attribute__((__unused__))
 #else
-#  define UNUSE(x) UNUSE_ ## x
+#define UNUSE(x) UNUSE_##x
 #endif
-
-void ACA_Vlan_Manager::set_oam_server_port(uint32_t UNUSE(tunnel_id), uint32_t UNUSE(port_number))
-{
-  ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::set_oam_server_port ---> Entering\n");
-
-  //TBD.
-
-  ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::set_oam_server_port <--- Exiting\n");
-}
 
 // create a neighbor port without specifying vpc_id and neighbor ID
 int ACA_Vlan_Manager::create_neighbor_outport(alcor::schema::NetworkType UNUSE(network_type),
-                                              string UNUSE(remote_host_ip), uint UNUSE(tunnel_id),
+                                              string UNUSE(remote_host_ip),
+                                              uint UNUSE(tunnel_id),
                                               ulong &UNUSE(culminative_time))
 {
   int overall_rc = EXIT_FAILURE;

--- a/src/zeta/aca_zeta_programming.cpp
+++ b/src/zeta/aca_zeta_programming.cpp
@@ -31,7 +31,8 @@ ACA_Zeta_Programming &ACA_Zeta_Programming::get_instance()
 }
 
 int ACA_Zeta_Programming::create_or_update_zeta_config(const alcor::schema::AuxGateway current_AuxGateway,
-                                                       const string vpc_id, uint32_t tunnel_id)
+                                                       const string /*vpc_id*/,
+                                                       uint32_t tunnel_id)
 {
   unsigned long not_care_culminative_time;
   int overall_rc;
@@ -51,10 +52,10 @@ int ACA_Zeta_Programming::create_or_update_zeta_config(const alcor::schema::AuxG
   }
   uint32_t oam_server_port = current_AuxGateway.zeta_info().port_inband_operation();
 
-  uint32_t oam_port = ACA_Vlan_Manager::get_instance().get_oam_server_port(vpc_id);
+  uint32_t oam_port = ACA_Vlan_Manager::get_instance().get_oam_server_port(tunnel_id);
   // oam_server_port is not set
   if (oam_port == 0) {
-    ACA_Vlan_Manager::get_instance().set_oam_server_port(vpc_id, oam_server_port);
+    ACA_Vlan_Manager::get_instance().set_oam_server_port(tunnel_id, oam_server_port);
 
     //update oam_ports_table and add the OAM punt rule also if this is the first port in the VPC
     Aca_Oam_Port_Manager::get_instance().add_vpc(oam_server_port, tunnel_id);
@@ -66,7 +67,7 @@ int ACA_Zeta_Programming::create_or_update_zeta_config(const alcor::schema::AuxG
 }
 
 int ACA_Zeta_Programming::delete_zeta_config(const alcor::schema::AuxGateway current_AuxGateway,
-                                             const string vpc_id, uint32_t tunnel_id)
+                                             const string /*vpc_id*/, uint32_t tunnel_id)
 {
   zeta_config stZetaCfg;
   int overall_rc;
@@ -78,7 +79,7 @@ int ACA_Zeta_Programming::delete_zeta_config(const alcor::schema::AuxGateway cur
   uint32_t oam_server_port = current_AuxGateway.zeta_info().port_inband_operation();
 
   // Reset oam_server_port to 0
-  ACA_Vlan_Manager::get_instance().set_oam_server_port(vpc_id, 0);
+  ACA_Vlan_Manager::get_instance().set_oam_server_port(tunnel_id, 0);
 
   // update oam_ports_table and delete the OAM punt rule if the last port in the VPC has been deleted
   Aca_Oam_Port_Manager::get_instance().remove_vpc(oam_server_port, tunnel_id);

--- a/test/func_tests/gs_tests.cpp
+++ b/test/func_tests/gs_tests.cpp
@@ -79,22 +79,22 @@ static void aca_cleanup()
 {
   ACA_LOG_DEBUG("g_total_execute_system_time = %lu microseconds or %lu milliseconds\n",
                 g_total_execute_system_time.load(),
-                g_total_execute_system_time.load() / 1000);
+                us_to_ms(g_total_execute_system_time.load()));
 
   ACA_LOG_DEBUG("g_total_execute_ovsdb_time = %lu microseconds or %lu milliseconds\n",
                 g_total_execute_ovsdb_time.load(),
-                g_total_execute_ovsdb_time.load() / 1000);
+                us_to_ms(g_total_execute_ovsdb_time.load()));
 
   ACA_LOG_DEBUG("g_total_execute_openflow_time = %lu microseconds or %lu milliseconds\n",
                 g_total_execute_openflow_time.load(),
-                g_total_execute_openflow_time.load() / 1000);
+                us_to_ms(g_total_execute_openflow_time.load()));
 
   ACA_LOG_DEBUG("g_total_vpcs_table_mutex_time = %lu microseconds or %lu milliseconds\n",
                 g_total_vpcs_table_mutex_time.load(),
-                g_total_vpcs_table_mutex_time.load() / 1000);
+                us_to_ms(g_total_vpcs_table_mutex_time.load()));
 
   ACA_LOG_DEBUG("g_total_update_GS_time = %lu microseconds or %lu milliseconds\n",
-                g_total_update_GS_time.load(), g_total_update_GS_time.load() / 1000);
+                g_total_update_GS_time.load(), us_to_ms(g_total_update_GS_time.load()));
 
   ACA_LOG_INFO("%s", "Program exiting, cleaning up...\n");
 
@@ -117,12 +117,12 @@ void print_goalstateReply(GoalStateOperationReply gsOperationReply)
                   gsOperationReply.operation_statuses(i).operation_status());
     ACA_LOG_DEBUG("gsOperationReply(%d) - total_operation_time: %u microseconds or %u milliseconds\n",
                   i, gsOperationReply.operation_statuses(i).state_elapse_time(),
-                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000);
+                  us_to_ms(gsOperationReply.operation_statuses(i).state_elapse_time()));
   }
 
   ACA_LOG_DEBUG("[METRICS] ACA message_total_operation_time: %u microseconds or %u milliseconds\n",
                 gsOperationReply.message_total_operation_time(),
-                gsOperationReply.message_total_operation_time() / 1000);
+                us_to_ms(gsOperationReply.message_total_operation_time()));
 
   g_total_ACA_Message_time += gsOperationReply.message_total_operation_time();
 }
@@ -150,7 +150,7 @@ class GoalStateProvisionerClient {
     auto rpc_ptr_time = cast_to_microseconds(after_rpc_ptr - before_rpc_ptr).count();
 
     ACA_LOG_INFO("[METRICS] rpc_ptr took: %ld microseconds or %ld milliseconds\n",
-                 rpc_ptr_time, rpc_ptr_time / 1000);
+                 rpc_ptr_time, us_to_ms(rpc_ptr_time));
 
     rpc->StartCall();
 
@@ -160,7 +160,7 @@ class GoalStateProvisionerClient {
             cast_to_microseconds(after_start_call - after_rpc_ptr).count();
 
     ACA_LOG_INFO("[METRICS] start_call took: %ld microseconds or %ld milliseconds\n",
-                 start_call_time, start_call_time / 1000);
+                 start_call_time, us_to_ms(start_call_time));
 
     rpc->Finish(&reply, &status, (void *)1);
 
@@ -169,12 +169,12 @@ class GoalStateProvisionerClient {
     auto finish_time = cast_to_microseconds(after_finish - after_start_call).count();
 
     ACA_LOG_INFO("[METRICS] finish took: %ld microseconds or %ld milliseconds\n",
-                 finish_time, finish_time / 1000);
+                 finish_time, us_to_ms(finish_time));
 
     auto total_time = cast_to_microseconds(after_finish - before_rpc_ptr).count();
 
     ACA_LOG_INFO("[METRICS] total async took: %ld microseconds or %ld milliseconds\n",
-                 total_time, total_time / 1000);
+                 total_time, us_to_ms(total_time));
 
     void *got_tag;
     bool ok = false;
@@ -204,7 +204,7 @@ class GoalStateProvisionerClient {
             cast_to_microseconds(after_sync_call - before_sync_call).count();
 
     ACA_LOG_INFO("[METRICS] PushNetworkResourceStates sync call took: %ld microseconds or %ld milliseconds\n",
-                 sync_call_time, sync_call_time / 1000);
+                 sync_call_time, us_to_ms(sync_call_time));
 
     if (!status.ok()) {
       ACA_LOG_ERROR("%s", "RPC call failed\n");
@@ -273,14 +273,15 @@ class GoalStateProvisionerClient {
             cast_to_microseconds(after_send_goalstate - before_send_goalstate).count();
 
     ACA_LOG_INFO("[***METRICS***] Grand ACA message_total_operation_time: %lu microseconds or %lu milliseconds\n",
-                 g_total_ACA_Message_time.load(), g_total_ACA_Message_time.load() / 1000);
+                 g_total_ACA_Message_time.load(),
+                 us_to_ms(g_total_ACA_Message_time.load()));
 
     ACA_LOG_INFO("[***METRICS***] GRPC E2E send_goalstate_sync call took: %ld microseconds or %ld milliseconds\n",
-                 send_goalstate_time, send_goalstate_time / 1000);
+                 send_goalstate_time, us_to_ms(send_goalstate_time));
 
     ACA_LOG_INFO("[***METRICS***] Total GRPC latency/usage for sync call: %ld microseconds or %ld milliseconds\n",
                  send_goalstate_time - g_total_ACA_Message_time.load(),
-                 (send_goalstate_time - g_total_ACA_Message_time.load()) / 1000);
+                 (send_goalstate_time - us_to_ms(g_total_ACA_Message_time.load())));
   }
 
   int send_goalstate_stream_one(GoalState &goalState, GoalStateOperationReply &gsOperationReply)
@@ -298,7 +299,7 @@ class GoalStateProvisionerClient {
             cast_to_microseconds(after_stream_create - before_stream_create).count();
 
     ACA_LOG_INFO("[METRICS] stream_create call took: %ld microseconds or %ld milliseconds\n",
-                 stream_create_time, stream_create_time / 1000);
+                 stream_create_time, us_to_ms(stream_create_time));
 
     std::thread writer([stream, goalState]() {
       stream->Write(goalState);
@@ -311,7 +312,7 @@ class GoalStateProvisionerClient {
             cast_to_microseconds(after_write_done - after_stream_create).count();
 
     ACA_LOG_INFO("[METRICS] write_done call took: %ld microseconds or %ld milliseconds\n",
-                 write_done_time, write_done_time / 1000);
+                 write_done_time, us_to_ms(write_done_time));
 
     while (stream->Read(&gsOperationReply)) {
       ACA_LOG_INFO("%s", "Received one streaming GoalStateOperationReply\n");
@@ -347,7 +348,7 @@ class GoalStateProvisionerClient {
             cast_to_microseconds(after_stream_create - before_stream_create).count();
 
     ACA_LOG_INFO("[METRICS] stream_create call took: %ld microseconds or %ld milliseconds\n",
-                 stream_create_time, stream_create_time / 1000);
+                 stream_create_time, us_to_ms(stream_create_time));
 
     std::thread writer([stream, states_to_create, ip_prefix]() {
       GoalState GoalState_builder;
@@ -404,7 +405,7 @@ class GoalStateProvisionerClient {
             cast_to_microseconds(after_write_done - after_stream_create).count();
 
     ACA_LOG_INFO("[METRICS] write_done call took: %ld microseconds or %ld milliseconds\n",
-                 write_done_time, write_done_time / 1000);
+                 write_done_time, us_to_ms(write_done_time));
 
     GoalStateOperationReply gsOperationReply;
     while (stream->Read(&gsOperationReply)) {
@@ -421,14 +422,15 @@ class GoalStateProvisionerClient {
             cast_to_microseconds(after_send_goalstate - before_send_goalstate).count();
 
     ACA_LOG_INFO("[***METRICS***] Grand ACA message_total_operation_time: %lu microseconds or %lu milliseconds\n",
-                 g_total_ACA_Message_time.load(), g_total_ACA_Message_time.load() / 1000);
+                 g_total_ACA_Message_time.load(),
+                 us_to_ms(g_total_ACA_Message_time.load()));
 
     ACA_LOG_INFO("[***METRICS***] Grand send_goalstate_sync call took: %ld microseconds or %ld milliseconds\n",
-                 send_goalstate_time, send_goalstate_time / 1000);
+                 send_goalstate_time, us_to_ms(send_goalstate_time));
 
     ACA_LOG_INFO("[***METRICS***] Total GRPC latency/usage for stream call: %ld microseconds or %ld milliseconds\n",
                  send_goalstate_time - g_total_ACA_Message_time.load(),
-                 (send_goalstate_time - g_total_ACA_Message_time.load()) / 1000);
+                 (send_goalstate_time - us_to_ms(g_total_ACA_Message_time.load())));
 
     if (!status.ok()) {
       ACA_LOG_ERROR("%s", "RPC call failed\n");
@@ -696,7 +698,7 @@ int main(int argc, char *argv[])
           cast_to_microseconds(after_grpc_client - before_grpc_client).count();
 
   ACA_LOG_INFO("[METRICS] grpc_client took: %ld microseconds or %ld milliseconds\n",
-               async_client_time, async_client_time / 1000);
+               async_client_time, us_to_ms(async_client_time));
 
   ACA_LOG_INFO("%s", "-------------- sending one goal state async --------------\n");
 
@@ -712,7 +714,7 @@ int main(int argc, char *argv[])
           cast_to_microseconds(after_send_goalstate - before_send_goalstate).count();
 
   ACA_LOG_INFO("[***METRICS***] send_goalstate_async call took: %ld microseconds or %ld milliseconds\n",
-               send_goalstate_time, send_goalstate_time / 1000);
+               send_goalstate_time, us_to_ms(send_goalstate_time));
 
   print_goalstateReply(async_reply);
 
@@ -753,7 +755,7 @@ int main(int argc, char *argv[])
             cast_to_microseconds(after_send_goalstate - before_send_goalstate).count();
 
     ACA_LOG_INFO("[***METRICS***] send_goalstate_stream_one call took: %ld microseconds or %ld milliseconds\n",
-                 send_goalstate_time, send_goalstate_time / 1000);
+                 send_goalstate_time, us_to_ms(send_goalstate_time));
 
     print_goalstateReply(stream_reply);
 

--- a/test/gtest/aca_test_main.cpp
+++ b/test/gtest/aca_test_main.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "aca_log.h"
+#include "aca_util.h"
 #include "gtest/gtest.h"
 #include "goalstate.pb.h"
 #include "aca_message_pulsar_producer.h"
@@ -78,22 +79,22 @@ static void aca_cleanup()
 {
   ACA_LOG_DEBUG("g_total_execute_system_time = %lu microseconds or %lu milliseconds\n",
                 g_total_execute_system_time.load(),
-                g_total_execute_system_time.load() / 1000);
+                us_to_ms(g_total_execute_system_time.load()));
 
   ACA_LOG_DEBUG("g_total_execute_ovsdb_time = %lu microseconds or %lu milliseconds\n",
                 g_total_execute_ovsdb_time.load(),
-                g_total_execute_ovsdb_time.load() / 1000);
+                us_to_ms(g_total_execute_ovsdb_time.load()));
 
   ACA_LOG_DEBUG("g_total_execute_openflow_time = %lu microseconds or %lu milliseconds\n",
                 g_total_execute_openflow_time.load(),
-                g_total_execute_openflow_time.load() / 1000);
+                us_to_ms(g_total_execute_openflow_time.load()));
 
   ACA_LOG_DEBUG("g_total_vpcs_table_mutex_time = %lu microseconds or %lu milliseconds\n",
                 g_total_vpcs_table_mutex_time.load(),
-                g_total_vpcs_table_mutex_time.load() / 1000);
+                us_to_ms(g_total_vpcs_table_mutex_time.load()));
 
   ACA_LOG_DEBUG("g_total_update_GS_time = %lu microseconds or %lu milliseconds\n",
-                g_total_update_GS_time.load(), g_total_update_GS_time.load() / 1000);
+                g_total_update_GS_time.load(), us_to_ms(g_total_update_GS_time.load()));
 
   ACA_LOG_INFO("%s", "Program exiting, cleaning up...\n");
 

--- a/test/gtest/aca_test_main.cpp
+++ b/test/gtest/aca_test_main.cpp
@@ -34,6 +34,7 @@ string g_ofctl_target = EMPTY_STRING;
 string g_ofctl_options = EMPTY_STRING;
 string remote_ip_1 = "172.17.0.2"; // for docker network
 string remote_ip_2 = "172.17.0.3"; // for docker network
+uint neighbors_to_create = 10;
 
 static string mq_broker_ip = "pulsar://localhost:6650"; //for the broker running in localhost
 static string mq_test_topic = "my-topic";
@@ -91,7 +92,7 @@ int main(int argc, char **argv)
 
   testing::InitGoogleTest(&argc, argv);
 
-  while ((option = getopt(argc, argv, "p:c:")) != -1) {
+  while ((option = getopt(argc, argv, "p:c:n:")) != -1) {
     switch (option) {
     case 'p':
       remote_ip_1 = optarg;
@@ -99,11 +100,15 @@ int main(int argc, char **argv)
     case 'c':
       remote_ip_2 = optarg;
       break;
+    case 'n':
+      neighbors_to_create = std::stoi(optarg);
+      break;
     default: /* the '?' case when the option is not recognized */
       fprintf(stderr,
               "Usage: %s\n"
               "\t\t[-m parent machine IP]\n"
-              "\t\t[-c child machine IP]\n",
+              "\t\t[-c child machine IP]\n"
+              "\t\t[-n neighbors to create (default: 10)]\n",
               argv[0]);
       exit(EXIT_FAILURE);
     }

--- a/test/gtest/aca_test_main.cpp
+++ b/test/gtest/aca_test_main.cpp
@@ -24,14 +24,25 @@ using namespace aca_message_pulsar;
 #define ACALOGNAME "AlcorControlAgentTest"
 
 // Global variables
-std::atomic_ulong g_total_network_configuration_time(0);
-std::atomic_ulong g_total_update_GS_time(0);
-bool g_debug_mode = true;
-bool g_demo_mode = false;
 static char EMPTY_STRING[] = "";
 string g_ofctl_command = EMPTY_STRING;
 string g_ofctl_target = EMPTY_STRING;
 string g_ofctl_options = EMPTY_STRING;
+
+// total time for execute_system_command in microseconds
+std::atomic_ulong g_total_execute_system_time(0);
+// total time for execute_ovsdb_command in microseconds
+std::atomic_ulong g_total_execute_ovsdb_time(0);
+// total time for execute_openflow_command in microseconds
+std::atomic_ulong g_total_execute_openflow_time(0);
+// total time for vpcs_table_mutex in microseconds
+std::atomic_ulong g_total_vpcs_table_mutex_time(0);
+// total time for goal state update in microseconds
+std::atomic_ulong g_total_update_GS_time(0);
+
+bool g_debug_mode = true;
+bool g_demo_mode = false;
+
 string remote_ip_1 = "172.17.0.2"; // for docker network
 string remote_ip_2 = "172.17.0.3"; // for docker network
 uint neighbors_to_create = 10;
@@ -65,12 +76,24 @@ TEST(pulsar_test_cases, DISABLED_pulsar_consumer_test)
 
 static void aca_cleanup()
 {
-  ACA_LOG_DEBUG("g_total_network_configuration_time = %lu nanoseconds or %lu milliseconds\n",
-                g_total_network_configuration_time.load(),
-                g_total_network_configuration_time.load() / 1000000);
+  ACA_LOG_DEBUG("g_total_execute_system_time = %lu microseconds or %lu milliseconds\n",
+                g_total_execute_system_time.load(),
+                g_total_execute_system_time.load() / 1000);
 
-  ACA_LOG_DEBUG("g_total_update_GS_time = %lu nanoseconds or %lu milliseconds\n",
-                g_total_update_GS_time.load(), g_total_update_GS_time.load() / 1000000);
+  ACA_LOG_DEBUG("g_total_execute_ovsdb_time = %lu microseconds or %lu milliseconds\n",
+                g_total_execute_ovsdb_time.load(),
+                g_total_execute_ovsdb_time.load() / 1000);
+
+  ACA_LOG_DEBUG("g_total_execute_openflow_time = %lu microseconds or %lu milliseconds\n",
+                g_total_execute_openflow_time.load(),
+                g_total_execute_openflow_time.load() / 1000);
+
+  ACA_LOG_DEBUG("g_total_vpcs_table_mutex_time = %lu microseconds or %lu milliseconds\n",
+                g_total_vpcs_table_mutex_time.load(),
+                g_total_vpcs_table_mutex_time.load() / 1000);
+
+  ACA_LOG_DEBUG("g_total_update_GS_time = %lu microseconds or %lu milliseconds\n",
+                g_total_update_GS_time.load(), g_total_update_GS_time.load() / 1000);
 
   ACA_LOG_INFO("%s", "Program exiting, cleaning up...\n");
 

--- a/test/gtest/aca_test_ovs_l2.cpp
+++ b/test/gtest/aca_test_ovs_l2.cpp
@@ -479,22 +479,21 @@ TEST(ovs_l2_test_cases, 10_ports_CREATE)
   ulong total_port_create_time = 0;
 
   for (int i = 0; i < PORTS_TO_CREATE; i++) {
-    ACA_LOG_DEBUG("Port State(%d) took: %u nanoseconds or %u milliseconds\n", i,
-                  gsOperationReply.operation_statuses(i).state_elapse_time(),
-                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000000);
+    ACA_LOG_DEBUG("Port State(%d) took: %u microseconds or %u milliseconds\n",
+                  i, gsOperationReply.operation_statuses(i).state_elapse_time(),
+                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000);
 
     total_port_create_time += gsOperationReply.operation_statuses(i).state_elapse_time();
   }
 
   ulong average_port_create_time = total_port_create_time / PORTS_TO_CREATE;
 
-  ACA_LOG_INFO("Average Port Create of %d took: %lu nanoseconds or %lu milliseconds\n",
-               PORTS_TO_CREATE, average_port_create_time,
-               average_port_create_time / 1000000);
+  ACA_LOG_INFO("Average Port Create of %d took: %lu microseconds or %lu milliseconds\n",
+               PORTS_TO_CREATE, average_port_create_time, average_port_create_time / 1000);
 
-  ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u nanoseconds or %u milliseconds\n",
+  ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u microseconds or %u milliseconds\n",
                gsOperationReply.message_total_operation_time(),
-               gsOperationReply.message_total_operation_time() / 1000000);
+               gsOperationReply.message_total_operation_time() / 1000);
 }
 
 TEST(ovs_l2_test_cases, 1_l2_neighbor_CREATE_DELETE)

--- a/test/gtest/aca_test_ovs_l2.cpp
+++ b/test/gtest/aca_test_ovs_l2.cpp
@@ -61,6 +61,7 @@ extern string subnet2_gw_ip;
 extern string subnet1_gw_mac;
 extern string subnet2_gw_mac;
 extern bool g_demo_mode;
+extern uint neighbors_to_create;
 
 extern void aca_test_create_default_port_state(PortState *new_port_states);
 extern void aca_test_create_default_subnet_state(SubnetState *new_subnet_states);
@@ -513,7 +514,7 @@ TEST(ovs_l2_test_cases, 10_l2_neighbor_CREATE)
 
 TEST(ovs_l2_test_cases, 1_port_CREATE_plus_10_l2_neighbor_CREATE)
 {
-  aca_test_1_port_CREATE_plus_X_neighbors_CREATE(NeighborType::L2, 10);
+  aca_test_1_port_CREATE_plus_X_neighbors_CREATE(NeighborType::L2, neighbors_to_create);
 }
 
 TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)

--- a/test/gtest/aca_test_ovs_l2.cpp
+++ b/test/gtest/aca_test_ovs_l2.cpp
@@ -481,7 +481,7 @@ TEST(ovs_l2_test_cases, 10_ports_CREATE)
   for (int i = 0; i < PORTS_TO_CREATE; i++) {
     ACA_LOG_DEBUG("Port State(%d) took: %u microseconds or %u milliseconds\n",
                   i, gsOperationReply.operation_statuses(i).state_elapse_time(),
-                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000);
+                  us_to_ms(gsOperationReply.operation_statuses(i).state_elapse_time()));
 
     total_port_create_time += gsOperationReply.operation_statuses(i).state_elapse_time();
   }
@@ -489,11 +489,12 @@ TEST(ovs_l2_test_cases, 10_ports_CREATE)
   ulong average_port_create_time = total_port_create_time / PORTS_TO_CREATE;
 
   ACA_LOG_INFO("Average Port Create of %d took: %lu microseconds or %lu milliseconds\n",
-               PORTS_TO_CREATE, average_port_create_time, average_port_create_time / 1000);
+               PORTS_TO_CREATE, average_port_create_time,
+               us_to_ms(average_port_create_time));
 
   ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u microseconds or %u milliseconds\n",
                gsOperationReply.message_total_operation_time(),
-               gsOperationReply.message_total_operation_time() / 1000);
+               us_to_ms(gsOperationReply.message_total_operation_time()));
 }
 
 TEST(ovs_l2_test_cases, 1_l2_neighbor_CREATE_DELETE)

--- a/test/gtest/aca_test_ovs_l2.cpp
+++ b/test/gtest/aca_test_ovs_l2.cpp
@@ -67,6 +67,8 @@ extern void aca_test_create_default_subnet_state(SubnetState *new_subnet_states)
 extern void aca_test_1_neighbor_CREATE_DELETE(NeighborType input_neighbor_type);
 extern void aca_test_1_port_CREATE_plus_neighbor_CREATE(NeighborType input_neighbor_type);
 extern void aca_test_10_neighbor_CREATE(NeighborType input_neighbor_type);
+extern void aca_test_1_port_CREATE_plus_X_neighbors_CREATE(NeighborType input_neighbor_type,
+                                                           uint neighbors_to_create);
 
 // TODO: setup bridge when br-int is up and br-tun is gone
 
@@ -191,7 +193,7 @@ TEST(ovs_l2_test_cases, 2_ports_CREATE_test_traffic_plus_neighbor_internal)
 
   // delete neighbor info
   overall_rc = ACA_OVS_L2_Programmer::get_instance().delete_l2_neighbor(
-          port_id_4, vpc_id_1, outport_name, not_care_culminative_time);
+          port_id_4, 20, outport_name, not_care_culminative_time);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
@@ -507,6 +509,11 @@ TEST(ovs_l2_test_cases, 1_port_CREATE_plus_l2_neighbor_CREATE)
 TEST(ovs_l2_test_cases, 10_l2_neighbor_CREATE)
 {
   aca_test_10_neighbor_CREATE(NeighborType::L2);
+}
+
+TEST(ovs_l2_test_cases, 1_port_CREATE_plus_10_l2_neighbor_CREATE)
+{
+  aca_test_1_port_CREATE_plus_X_neighbors_CREATE(NeighborType::L2, 10);
 }
 
 TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)

--- a/test/gtest/aca_test_ovs_util.cpp
+++ b/test/gtest/aca_test_ovs_util.cpp
@@ -406,9 +406,9 @@ void aca_test_10_neighbor_CREATE(NeighborType input_neighbor_type)
   ulong total_neighbor_create_time = 0;
 
   for (int i = 0; i < NEIGHBORS_TO_CREATE; i++) {
-    ACA_LOG_DEBUG("Neighbor State(%d) took: %u nanoseconds or %u milliseconds\n",
+    ACA_LOG_DEBUG("Neighbor State(%d) took: %u microseconds or %u milliseconds\n",
                   i, gsOperationReply.operation_statuses(i).state_elapse_time(),
-                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000000);
+                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000);
 
     total_neighbor_create_time +=
             gsOperationReply.operation_statuses(i).state_elapse_time();
@@ -416,13 +416,13 @@ void aca_test_10_neighbor_CREATE(NeighborType input_neighbor_type)
 
   ulong average_neighbor_create_time = total_neighbor_create_time / NEIGHBORS_TO_CREATE;
 
-  ACA_LOG_INFO("Average NeighborType: %d Create of %d took: %lu nanoseconds or %lu milliseconds\n",
-               input_neighbor_type, NEIGHBORS_TO_CREATE, average_neighbor_create_time,
-               average_neighbor_create_time / 1000000);
+  ACA_LOG_INFO("Average NeighborType: %d Create of %d took: %lu microseconds or %lu milliseconds\n",
+               input_neighbor_type, NEIGHBORS_TO_CREATE,
+               average_neighbor_create_time, average_neighbor_create_time / 1000);
 
-  ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u nanoseconds or %u milliseconds\n",
+  ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u microseconds or %u milliseconds\n",
                gsOperationReply.message_total_operation_time(),
-               gsOperationReply.message_total_operation_time() / 1000000);
+               gsOperationReply.message_total_operation_time() / 1000);
 }
 
 void aca_test_1_port_CREATE_plus_X_neighbors_CREATE(NeighborType input_neighbor_type,
@@ -507,11 +507,11 @@ void aca_test_1_port_CREATE_plus_X_neighbors_CREATE(NeighborType input_neighbor_
 
   // we have neighbors_to_create + 1 port state created
   for (uint i = 0; i < neighbors_to_create + 1; i++) {
-    ACA_LOG_DEBUG("Number: %d Resource Type: %d with id: %s took: %u nanoseconds or %u milliseconds\n",
+    ACA_LOG_DEBUG("Number: %d Resource Type: %d with id: %s took: %u microseconds or %u milliseconds\n",
                   i, gsOperationReply.operation_statuses(i).resource_type(),
                   gsOperationReply.operation_statuses(i).resource_id().c_str(),
                   gsOperationReply.operation_statuses(i).state_elapse_time(),
-                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000000);
+                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000);
 
     total_neighbor_create_time +=
             gsOperationReply.operation_statuses(i).state_elapse_time();
@@ -519,11 +519,11 @@ void aca_test_1_port_CREATE_plus_X_neighbors_CREATE(NeighborType input_neighbor_
 
   ulong average_neighbor_create_time = total_neighbor_create_time / neighbors_to_create;
 
-  ACA_LOG_INFO("Average port + neighbor states with NeighborType: %d Create of %d took: %lu nanoseconds or %lu milliseconds\n",
-               input_neighbor_type, neighbors_to_create, average_neighbor_create_time,
-               average_neighbor_create_time / 1000000);
+  ACA_LOG_INFO("Average port + neighbor states with NeighborType: %d Create of %d took: %lu microseconds or %lu milliseconds\n",
+               input_neighbor_type, neighbors_to_create,
+               average_neighbor_create_time, average_neighbor_create_time / 1000);
 
-  ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u nanoseconds or %u milliseconds\n",
+  ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u microseconds or %u milliseconds\n",
                gsOperationReply.message_total_operation_time(),
-               gsOperationReply.message_total_operation_time() / 1000000);
+               gsOperationReply.message_total_operation_time() / 1000);
 }

--- a/test/gtest/aca_test_ovs_util.cpp
+++ b/test/gtest/aca_test_ovs_util.cpp
@@ -408,7 +408,7 @@ void aca_test_10_neighbor_CREATE(NeighborType input_neighbor_type)
   for (int i = 0; i < NEIGHBORS_TO_CREATE; i++) {
     ACA_LOG_DEBUG("Neighbor State(%d) took: %u microseconds or %u milliseconds\n",
                   i, gsOperationReply.operation_statuses(i).state_elapse_time(),
-                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000);
+                  us_to_ms(gsOperationReply.operation_statuses(i).state_elapse_time()));
 
     total_neighbor_create_time +=
             gsOperationReply.operation_statuses(i).state_elapse_time();
@@ -417,12 +417,12 @@ void aca_test_10_neighbor_CREATE(NeighborType input_neighbor_type)
   ulong average_neighbor_create_time = total_neighbor_create_time / NEIGHBORS_TO_CREATE;
 
   ACA_LOG_INFO("Average NeighborType: %d Create of %d took: %lu microseconds or %lu milliseconds\n",
-               input_neighbor_type, NEIGHBORS_TO_CREATE,
-               average_neighbor_create_time, average_neighbor_create_time / 1000);
+               input_neighbor_type, NEIGHBORS_TO_CREATE, average_neighbor_create_time,
+               us_to_ms(average_neighbor_create_time));
 
   ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u microseconds or %u milliseconds\n",
                gsOperationReply.message_total_operation_time(),
-               gsOperationReply.message_total_operation_time() / 1000);
+               gsOperationReply.us_to_ms(message_total_operation_time()));
 }
 
 void aca_test_1_port_CREATE_plus_X_neighbors_CREATE(NeighborType input_neighbor_type,
@@ -511,7 +511,7 @@ void aca_test_1_port_CREATE_plus_X_neighbors_CREATE(NeighborType input_neighbor_
                   i, gsOperationReply.operation_statuses(i).resource_type(),
                   gsOperationReply.operation_statuses(i).resource_id().c_str(),
                   gsOperationReply.operation_statuses(i).state_elapse_time(),
-                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000);
+                  us_to_ms(gsOperationReply.operation_statuses(i).state_elapse_time()));
 
     total_neighbor_create_time +=
             gsOperationReply.operation_statuses(i).state_elapse_time();
@@ -520,10 +520,10 @@ void aca_test_1_port_CREATE_plus_X_neighbors_CREATE(NeighborType input_neighbor_
   ulong average_neighbor_create_time = total_neighbor_create_time / neighbors_to_create;
 
   ACA_LOG_INFO("Average port + neighbor states with NeighborType: %d Create of %d took: %lu microseconds or %lu milliseconds\n",
-               input_neighbor_type, neighbors_to_create,
-               average_neighbor_create_time, average_neighbor_create_time / 1000);
+               input_neighbor_type, neighbors_to_create, average_neighbor_create_time,
+               us_to_ms(average_neighbor_create_time));
 
   ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u microseconds or %u milliseconds\n",
                gsOperationReply.message_total_operation_time(),
-               gsOperationReply.message_total_operation_time() / 1000);
+               us_to_ms(gsOperationReply.message_total_operation_time()));
 }

--- a/test/gtest/aca_test_ovs_util.cpp
+++ b/test/gtest/aca_test_ovs_util.cpp
@@ -424,3 +424,106 @@ void aca_test_10_neighbor_CREATE(NeighborType input_neighbor_type)
                gsOperationReply.message_total_operation_time(),
                gsOperationReply.message_total_operation_time() / 1000000);
 }
+
+void aca_test_1_port_CREATE_plus_X_neighbors_CREATE(NeighborType input_neighbor_type,
+                                                    uint neighbors_to_create)
+{
+  string port_name_postfix = "-2222-3333-4444-555555555555";
+  string neighbor_id_postfix = "-baad-f00d-4444-555555555555";
+  string ip_address_prefix = "10.";
+  string remote_ip_address_prefix = "123.";
+  int overall_rc;
+
+  // current algorithm only supports up to 1,000,000 neighbors
+  if (neighbors_to_create > 1000000) {
+    ACA_LOG_DEBUG("Number of Neighbors is too large: %u\n", neighbors_to_create);
+    ASSERT_FALSE(true);
+  }
+
+  aca_test_reset_environment();
+
+  GoalState GoalState_builder;
+  NeighborState *new_neighbor_states;
+
+  if (input_neighbor_type == NeighborType::L3) {
+    aca_test_create_default_router_goal_state(&GoalState_builder);
+  } else {
+    // fill in subnet state structs for L2 path only
+    // because the L3 path above already added it
+    SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
+    aca_test_create_default_subnet_state(new_subnet_states);
+  }
+
+  PortState *new_port_states = GoalState_builder.add_port_states();
+
+  // fill in port state structs
+  aca_test_create_default_port_state(new_port_states);
+
+  for (uint i = 0; i < neighbors_to_create; i++) {
+    string i_string = std::to_string(i);
+    string neighbor_id = i_string + neighbor_id_postfix;
+    string port_name = i_string + port_name_postfix;
+
+    string ip_2nd_octet = std::to_string(i / 10000);
+    string ip_3rd_octet = std::to_string(i % 10000 / 100);
+    string ip_4th_octet = std::to_string(i % 100);
+
+    string ip_postfix = ip_2nd_octet + "." + ip_3rd_octet + "." + ip_4th_octet;
+    string remote_ip = remote_ip_address_prefix + ip_postfix;
+    string virtual_ip = ip_address_prefix + ip_postfix;
+
+    new_neighbor_states = GoalState_builder.add_neighbor_states();
+    new_neighbor_states->set_operation_type(OperationType::CREATE);
+
+    NeighborConfiguration *NeighborConfiguration_builder =
+            new_neighbor_states->mutable_configuration();
+    NeighborConfiguration_builder->set_revision_number(1);
+
+    NeighborConfiguration_builder->set_vpc_id("1b08a5bc-b718-11ea-b3de-111122223333");
+    NeighborConfiguration_builder->set_id(neighbor_id);
+    NeighborConfiguration_builder->set_name(port_name);
+    NeighborConfiguration_builder->set_mac_address(vmac_address_1);
+    NeighborConfiguration_builder->set_host_ip_address(remote_ip);
+
+    NeighborConfiguration_FixedIp *FixedIp_builder =
+            NeighborConfiguration_builder->add_fixed_ips();
+    FixedIp_builder->set_neighbor_type(input_neighbor_type);
+    FixedIp_builder->set_subnet_id(subnet_id_1);
+    FixedIp_builder->set_ip_address(virtual_ip);
+  }
+
+  bool previous_demo_mode = g_demo_mode;
+  g_demo_mode = true;
+
+  GoalStateOperationReply gsOperationReply;
+  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
+          GoalState_builder, gsOperationReply);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+
+  g_demo_mode = previous_demo_mode;
+
+  // calculate the average latency
+  ulong total_neighbor_create_time = 0;
+
+  // we have neighbors_to_create + 1 port state created
+  for (uint i = 0; i < neighbors_to_create + 1; i++) {
+    ACA_LOG_DEBUG("Number: %d Resource Type: %d with id: %s took: %u nanoseconds or %u milliseconds\n",
+                  i, gsOperationReply.operation_statuses(i).resource_type(),
+                  gsOperationReply.operation_statuses(i).resource_id().c_str(),
+                  gsOperationReply.operation_statuses(i).state_elapse_time(),
+                  gsOperationReply.operation_statuses(i).state_elapse_time() / 1000000);
+
+    total_neighbor_create_time +=
+            gsOperationReply.operation_statuses(i).state_elapse_time();
+  }
+
+  ulong average_neighbor_create_time = total_neighbor_create_time / neighbors_to_create;
+
+  ACA_LOG_INFO("Average port + neighbor states with NeighborType: %d Create of %d took: %lu nanoseconds or %lu milliseconds\n",
+               input_neighbor_type, neighbors_to_create, average_neighbor_create_time,
+               average_neighbor_create_time / 1000000);
+
+  ACA_LOG_INFO("[TEST METRICS] Elapsed time for message total operation took: %u nanoseconds or %u milliseconds\n",
+               gsOperationReply.message_total_operation_time(),
+               gsOperationReply.message_total_operation_time() / 1000000);
+}


### PR DESCRIPTION
This PR includes:

1. change _vpcs_table hashtable to use tunnel ID as the key to support Zeta
1. update the corresponding implementation for the above
1. added test case for upto 1,000,000 neighbors in one goal state for perf profiling in progress
1. added more metric data collection for ACA perf analysis
1. confirm all test cases are passing