### PR TITLE
[Zeta] Improved scale test with corrected port_id, concurrent execution for GTests.

### DIFF
--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -17,6 +17,7 @@
 #include "aca_util.h"
 #include "goalstateprovisioner.grpc.pb.h"
 #include <string.h>
+#include "aca_ovs_l2_programmer.h"
 #include "aca_comm_mgr.h"
 #include "aca_zeta_programming.h"
 #include "aca_util.h"
@@ -28,6 +29,7 @@
 using namespace aca_comm_manager;
 using namespace alcor::schema;
 using namespace aca_zeta_programming;
+using namespace aca_ovs_l2_programmer;
 
 extern string vmac_address_1;
 extern string vmac_address_2;
@@ -317,6 +319,20 @@ TEST(zeta_programming_test_cases, DISABLED_zeta_gateway_path_PARENT)
 
 
 TEST(zeta_programming_test_cases, DISABLED_zeta_scale_CHILD){
+    // ulong culminative_network_configuration_time = 0;
+  ulong not_care_culminative_time = 0;
+  int overall_rc = EXIT_SUCCESS;
+  // delete br-int and br-tun bridges
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-int", not_care_culminative_time, overall_rc);
+
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-tun", not_care_culminative_time, overall_rc);
+
+  // create and setup br-int and br-tun bridges, and their patch ports
+  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
   // set demo mode
   bool previous_demo_mode = g_demo_mode;
   g_demo_mode = true;
@@ -328,6 +344,20 @@ TEST(zeta_programming_test_cases, DISABLED_zeta_scale_CHILD){
 }
 
 TEST(zeta_programming_test_cases, DISABLED_zeta_scale_PARENT){
+  // ulong culminative_network_configuration_time = 0;
+  ulong not_care_culminative_time = 0;
+  int overall_rc = EXIT_SUCCESS;
+  // delete br-int and br-tun bridges
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-int", not_care_culminative_time, overall_rc);
+
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-tun", not_care_culminative_time, overall_rc);
+
+  // create and setup br-int and br-tun bridges, and their patch ports
+  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
   // set demo mode
   bool previous_demo_mode = g_demo_mode;
   g_demo_mode = true;

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -335,7 +335,20 @@ def run():
     test_end_time = time.time()
     print(
         f'Time took for the tests of ACA nodes are {test_end_time - test_start_time} seconds.')
+    print('Time for the Ping test')
+    
 
+    parent_ports = [port for port in zeta_data['PORT_data'] if port['ip_node'].split('.')[3] == zeta_data['aca_nodes'][0].split()[3]]
+    child_ports = [port for port in zeta_data['PORT_data'] if port['ip_node'].split('.')[3] == zeta_data['aca_nodes'][1].split()[3]]
+    print(f'Parent ports: {parent_ports}')
+    print(f'Child ports: {child_ports}')
+
+    if len(parent_ports) > 0 and len(child_ports) > 0:
+        ping_cmd = [f'ping -I {parent_ports[0]["ips_port"][0]["ip"]} -c1 {child_ports[0]["ips_port"][0]["ip"]}']
+        print(f'Command for ping: {ping_cmd[0]}')
+        exec_sshCommand_aca(host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=ping_cmd, timeout=20)
+    else:
+        print(f'Either parent or child does not have any ports, somethings wrong.')
 
 if __name__ == '__main__':
     run()

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -179,6 +179,7 @@ def talk_to_zeta(file_path, zgc_api_url, zeta_data, port_api_upper_limit, time_i
     with open('aca_data.json', 'w') as outfile:
         json.dump(json_content_for_aca, outfile)
         print(f'The aca data is exported to {aca_data_local_path}')
+    return json_content_for_aca
 
 # the ports' info inside are based on the PORT_data in zeta_data.json, please modify it accordingly to suit your needs
 
@@ -300,7 +301,7 @@ def run():
         print(
             f'Set time interval between /nodes POST calls to be {arg3} seconds.')
 
-    talk_to_zeta(file_path, zgc_api_url, zeta_data,
+    json_content_for_aca = talk_to_zeta(file_path, zgc_api_url, zeta_data,
                  port_api_upper_limit, time_interval_between_calls_in_seconds)
 
     aca_nodes_data = zeta_data["aca_nodes"]
@@ -338,8 +339,8 @@ def run():
     print('Time for the Ping test')
     
 
-    parent_ports = [port for port in zeta_data['PORT_data'] if port['ip_node'].split('.')[3] == zeta_data['aca_nodes'][0].split()[3]]
-    child_ports = [port for port in zeta_data['PORT_data'] if port['ip_node'].split('.')[3] == zeta_data['aca_nodes'][1].split()[3]]
+    parent_ports = [port for port in json_content_for_aca['port_response'] if port['ip_node'].split('.')[3] == zeta_data['aca_nodes'][0].split()[3]]
+    child_ports = [port for port in json_content_for_aca['port_response'] if port['ip_node'].split('.')[3] == zeta_data['aca_nodes'][1].split()[3]]
     print(f'Parent ports: {parent_ports}')
     print(f'Child ports: {child_ports}')
 

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -339,8 +339,8 @@ def run():
     print('Time for the Ping test')
     
 
-    parent_ports = [port for port in json_content_for_aca['port_response'] if port['ip_node'].split('.')[3] == zeta_data['aca_nodes'][0].split()[3]]
-    child_ports = [port for port in json_content_for_aca['port_response'] if port['ip_node'].split('.')[3] == zeta_data['aca_nodes'][1].split()[3]]
+    parent_ports = [port for port in json_content_for_aca['port_response'] if port['ip_node'].split('.')[3] == zeta_data['aca_nodes']['ip'][0].split()[3]]
+    child_ports = [port for port in json_content_for_aca['port_response'] if port['ip_node'].split('.')[3] == zeta_data['aca_nodes']['ip'][1].split()[3]]
     print(f'Parent ports: {parent_ports}')
     print(f'Child ports: {child_ports}')
 

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -218,21 +218,15 @@ def generate_ports(ports_to_create):
     print(f'Need to generate {ports_to_create} ports')
     node_data = {}
     all_ports_generated = []
-    unique_ips = set()
-    unique_macs = set()
-    unique_port_ids = set()
     for i in range(ports_to_create):
         port_template_to_use = get_port_template(i)
-        port_id = '99976feae-7dec-11d0-a765-00a0c{0:07d}'.format(i)
-        unique_port_ids.add(port_id)
+        port_id = '{0:07d}ae-7dec-11d0-a765-00a0c9341120'.format(i)
         ip_2nd_octet = str((i // 10000))
         ip_3rd_octet = str((i % 10000 // 100))
         ip_4th_octet = str((i % 100))
         ip = ips_ports_ip_prefix + ip_2nd_octet + \
             "." + ip_3rd_octet + "." + ip_4th_octet
-        unique_ips.add(ip)
         mac = mac_port_prefix + ip_2nd_octet + ":" + ip_3rd_octet + ":" + ip_4th_octet
-        unique_macs.add(mac)
         port_template_to_use['port_id'] = port_id
         port_template_to_use['ips_port'][0]['ip'] = ip
         port_template_to_use['mac_port'] = mac
@@ -341,8 +335,6 @@ def run():
 
     parent_ports = [port for port in json_content_for_aca['port_response'] if (port['ip_node'].split('.'))[3] == (zeta_data['aca_nodes']['ip'][0].split('.'))[3]]
     child_ports = [port for port in json_content_for_aca['port_response'] if (port['ip_node'].split('.'))[3] == (zeta_data['aca_nodes']['ip'][1].split('.'))[3]]
-    print(f'Parent ports: {parent_ports}')
-    print(f'Child ports: {child_ports}')
 
     if len(parent_ports) > 0 and len(child_ports) > 0:
         ping_cmd = [f'ping -I {parent_ports[0]["ips_port"][0]["ip"]} -c1 {child_ports[0]["ips_port"][0]["ip"]}']

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -339,8 +339,8 @@ def run():
     print('Time for the Ping test')
     
 
-    parent_ports = [port for port in json_content_for_aca['port_response'] if port['ip_node'].split('.')[3] == zeta_data['aca_nodes']['ip'][0].split()[3]]
-    child_ports = [port for port in json_content_for_aca['port_response'] if port['ip_node'].split('.')[3] == zeta_data['aca_nodes']['ip'][1].split()[3]]
+    parent_ports = [port for port in json_content_for_aca['port_response'] if (port['ip_node'].split('.'))[3] == (zeta_data['aca_nodes']['ip'][0].split('.'))[3]]
+    child_ports = [port for port in json_content_for_aca['port_response'] if (port['ip_node'].split('.'))[3] == (zeta_data['aca_nodes']['ip'][1].split('.'))[3]]
     print(f'Parent ports: {parent_ports}')
     print(f'Child ports: {child_ports}')
 

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -321,9 +321,9 @@ def run():
                           server_aca_repo_path + aca_data_destination_path, aca_data_local_path)
     if not res:
         print("upload file %s failed" % aca_data_local_path)
+        return
     else:
         print("upload file %s successfully" % aca_data_local_path)
-        return
 
     test_start_time = time.time()
     # Execute remote command, use the transferred file to change the information in aca_test_ovs_util.cpp,recompile using 'make',perform aca_test

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -313,36 +313,25 @@ def run():
     test_start_time = time.time()
     # Execute remote command, use the transferred file to change the information in aca_test_ovs_util.cpp,recompile using 'make',perform aca_test
     aca_nodes = aca_nodes_ip
-    cmd_list2 = [
+    cmd_child = [
         f'cd {server_aca_repo_path};sudo ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*{testcases_to_run[0]}']
-    # t1 = threading.Thread(target=exec_sshCommand_aca, args=(
-    #     aca_nodes[1], aca_nodes_data['username'], aca_nodes_data['password'], cmd_list2, 1500))
 
-    cmd_list1 = [
+    cmd_parent = [
         f'cd {server_aca_repo_path};sudo ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*{testcases_to_run[1]}']
 
-    # t2 = threading.Thread(target=exec_sshCommand_aca, args=(
-    #     aca_nodes[0], aca_nodes_data['username'], aca_nodes_data['password'], cmd_list1, 1500))
-
-    # t1.start()
-    # t2.start()
-
-    # t1.join()
-    # t2.join()
-    # param_list = [
-    #                 f'cd {server_aca_repo_path};sudo ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*{testcases_to_run[0]}',
-    #                 f'cd {server_aca_repo_path};sudo ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*{testcases_to_run[1]}'
-    #             ]
-    results = []
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        # future = [executor.submit(exec_sshCommand_aca, param) for param in param_list]
-        # results = [f.results() for f in futures]
-        future_child = executor.submit(exec_sshCommand_aca, aca_nodes[1], aca_nodes_data['username'], aca_nodes_data['password'], cmd_list2, 1500)
-        future_parent = executor.submit(exec_sshCommand_aca, aca_nodes[0], aca_nodes_data['username'], aca_nodes_data['password'], cmd_list1, 1500)
-        results.append(future_child.result())
-        results.append(future_parent.result())
-    for result in results:
-        print(f'Status: {result["status"]}, data: {result["data"]}, error: {result["error"]}')
+        future_child = executor.submit(exec_sshCommand_aca, aca_nodes[1], aca_nodes_data['username'], aca_nodes_data['password'], cmd_child, 1500)
+        future_parent = executor.submit(exec_sshCommand_aca, aca_nodes[0], aca_nodes_data['username'], aca_nodes_data['password'], cmd_parent, 1500)
+        result_child = future_child.result()
+        result_parent = future_parent.result()
+        for status_code in result_child["status"]:
+            if status_code != 0:
+                print(f'Child command: [{cmd_child}] failed, pseudo controller will stop now.')
+                return
+        for status_code in result_parent["status"]:
+            if status_code != 0:
+                print(f'Parent command: [{cmd_parent}] failed, pseudo controller will stop now.')
+                return
     
     test_end_time = time.time()
     print(
@@ -359,7 +348,7 @@ def run():
         ping_result = exec_sshCommand_aca(host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=ping_cmd, timeout=20)
     else:
         print(f'Either parent or child does not have any ports, somethings wrong.')
-    print(f'Ping result: {ping_result}')
+    print(f'Ping succeeded: {ping_result["status"][0] == 0}')
 
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
The goal of this PR is to improve the scale test. 

Changes include: 
- Changed the formatting of port_id, which leads to errors in `DISABLED_zeta_scale_CHILD` and `DISABLED_zeta_scale_PARENT`, which were unseen before. For more info, please refer to [here](https://github.com/futurewei-cloud/alcor-control-agent/pull/180#issuecomment-747672395).
- Optimized error handling when calling the Zeta APIs, if there's an unsuccessful call, the pseudo controller will stop right there.
- Added concurrent execution for gtests, which can potentially save a lot of time when creating more and more ports.
- Added logic to ping between port after all ports are set successfully.
- Optimized `DISABLED_zeta_scale_CHILD` and `DISABLED_zeta_scale_PARENT`, added logic to clean up existing bridges before the tests. 
- Added flags to control the amount of ports to create per `/ports POST` call, and to control how much time the pseudo controller sleeps after each call. 

There are now two ways to use the controller:
1. To create only two ports (by default) and run the tests `DISABLED_zeta_gateway_path_CHILD` and `DISABLED_zeta_gateway_path_PARENT`, user only need to run: 

`python3 run.py`

2. To create up to 1,000,000 port and run the tests `DISABLED_zeta_scale_CHILD` and `DISABLED_zeta_scale_PARENT`, with flags to control how many ports to create in total, how many ports each `/ports POST` call should generate(up to 4,000 ports), and how much time the pseudo controller sleeps after each call, the user should run: 

`python3 run.py total_ports_to_create number_of_ports_each_call amount_of_time_to_sleep`.
