### PR TITLE
[Zeta] fix concurrency errors and change the oam_cache data structure (#188)

### DIFF
--- a/include/aca_zeta_oam_server.h
+++ b/include/aca_zeta_oam_server.h
@@ -20,7 +20,7 @@
 #include <arpa/inet.h>
 #include <net/ethernet.h>
 #include <netinet/ether.h>
-
+#include "hashmap/HashMap.h"
 #include "goalstateprovisioner.grpc.pb.h"
 
 using namespace std;
@@ -101,7 +101,7 @@ class ACA_Zeta_Oam_Server {
 
   int _add_direct_path(oam_match match, oam_action action);
   int _del_direct_path(oam_match match);
-  
+
   void _init_oam_msg_ops();
   void _parse_oam_flow_injection(uint32_t udp_dport, oam_message *oammsg);
   void _parse_oam_flow_deletion(uint32_t udp_dport, oam_message *oammsg);
@@ -110,11 +110,8 @@ class ACA_Zeta_Oam_Server {
   void (aca_zeta_oam_server::ACA_Zeta_Oam_Server ::*_parse_oam_msg_ops[OAM_MSG_MAX])(
           uint32_t udp_dpost, oam_message *oammsg);
 
-  // unordered_set<oam_port_number>
-  unordered_set<uint> _oam_ports_cache;
-
-  // mutex for reading and writing to _oam_ports_cache
-  mutex _oam_ports_cache_mutex;
+  //  hashtable <key: oam_port, value: int *(not used)>
+  CTSL::HashMap<uint, int *> _oam_ports_cache;
 };
 } // namespace aca_zeta_oam_server
 #endif // #ifndef ACA_Zeta_OAM_SERVER_H

--- a/src/zeta/aca_zeta_oam_server.cpp
+++ b/src/zeta/aca_zeta_oam_server.cpp
@@ -136,7 +136,7 @@ uint ACA_Zeta_Oam_Server::_get_tunnel_id(uint8_t *vni)
 
   // Convert tunnel_id to uint
   // from uint8[3] to uint
-  tunnel_id = ((uint)vni[0]) | ((uint)vni[1]) << 8 | ((uint) vni[2]) << 16;
+  tunnel_id = ((uint)vni[0]) | ((uint)vni[1]) << 8 | ((uint)vni[2]) << 16;
 
   return tunnel_id;
 }
@@ -300,18 +300,16 @@ int ACA_Zeta_Oam_Server::_del_direct_path(oam_match match)
 // add oam port number to cache
 void ACA_Zeta_Oam_Server::add_oam_port_cache(uint port_number)
 {
-  if (_oam_ports_cache.find(port_number) == _oam_ports_cache.end()) {
-    _oam_ports_cache.emplace(port_number);
+  int *not_used;
+  if (!_oam_ports_cache.find(port_number, not_used)) {
+    _oam_ports_cache.insert(port_number, nullptr);
   }
 }
 
 // find the oam port number in the cache
 bool ACA_Zeta_Oam_Server::lookup_oam_port_in_cache(uint port_number)
 {
-  if (_oam_ports_cache.find(port_number) != _oam_ports_cache.end()) {
-    return true;
-  } else {
-    return false;
-  }
+  int *not_used;
+  return _oam_ports_cache.find(port_number, not_used);
 }
 } // namespace aca_zeta_oam_server

--- a/src/zeta/aca_zeta_programming.cpp
+++ b/src/zeta/aca_zeta_programming.cpp
@@ -198,7 +198,6 @@ int ACA_Zeta_Programming::create_zeta_config(const alcor::schema::AuxGateway cur
   if (!_zeta_config_table.find(current_AuxGateway.id(), current_zeta_cfg)) {
     create_entry(current_AuxGateway.id(), oam_port, current_AuxGateway);
     _zeta_config_table.find(current_AuxGateway.id(), current_zeta_cfg);
-
     overall_rc = _create_zeta_group_entry(current_zeta_cfg);
 
     _create_oam_ofp(oam_port);
@@ -372,9 +371,13 @@ int ACA_Zeta_Programming::_update_zeta_group_entry(zeta_config *zeta_cfg)
     }
   }
 
+  //-----Start unique lock-----
+  std::unique_lock<std::timed_mutex> group_entry_lock(_group_operation_mutex);
   // add group table rule
   aca_ovs_l2_programmer::ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
           cmd, not_care_culminative_time, overall_rc);
+  group_entry_lock.unlock();
+  //-----End unique lock-----
 
   if (overall_rc == EXIT_SUCCESS) {
     ACA_LOG_INFO("%s", "update_zeta_group_entry succeeded!\n");


### PR DESCRIPTION
#188  Fix concurrency errors and change the cache data structure to CTSL::HashMap. @er1cthe0ne 
1. The lock is still retained (an error will occur after the lock is removed), but it is moved inside the method.
2. In my environment, there will be no concurrent quit errors.