### PR TITLE
[Zeta] added non-ovs path for handling OAM packet

### DIFF
--- a/src/zeta/aca_zeta_programming.cpp
+++ b/src/zeta/aca_zeta_programming.cpp
@@ -203,11 +203,8 @@ void start_upd_listener(uint oam_port_number){
   portList.sin_family = AF_INET;
   portList.sin_port = htons(oam_port_number);
   // listen to all interfaces
-  portList.sin_addr.s_addr =  inet_addr(INADDR_ANY);
+  portList.sin_addr.s_addr =  htonl(INADDR_ANY);
 
-  if ( portList.sin_addr.s_addr == INADDR_NONE ) {
-    strerror(errno);
-  }
   len_inet = sizeof portList;
 
   z = bind(s, (struct sockaddr *)&portList, len_inet);

--- a/src/zeta/aca_zeta_programming.cpp
+++ b/src/zeta/aca_zeta_programming.cpp
@@ -221,6 +221,12 @@ void start_upd_listener(uint oam_port_number){
     ACA_LOG_INFO("Got this udp packet when listening to port %d\n", oam_port_number);
     ACA_LOG_INFO("dgram content: %s\n", dgram);
     std::cout << dgram << std::endl;
+    ACA_OVS_Control::get_instance().print_payload(reinterpret_cast<const unsigned char *>(dgram), z);
+    std::cout << "Printing char by char: " << std::endl;
+    for (uint i = 0 ; i < strlen(dgram); i++){
+      std::cout << dgram[i];
+    }
+    std::cout << "\nThis is the end" << std::endl;
     aca_zeta_oam_server::ACA_Zeta_Oam_Server::get_instance().oams_recv((uint32_t)oam_port_number, dgram);
   }
 }

--- a/src/zeta/aca_zeta_programming.cpp
+++ b/src/zeta/aca_zeta_programming.cpp
@@ -188,15 +188,15 @@ uint ACA_Zeta_Programming::get_oam_port(string zeta_gateway_id)
 }
 void start_upd_listener(uint oam_port_number){
   ACA_LOG_INFO("Starting a listener for port %d\n", oam_port_number);
-  int z;
+  int packet_length;
   struct sockaddr_in portList;
   int len_inet;
-  int s;
-  char dgram[512];
+  int socket_instance;
+  char packet_content[512];
   // time_t td;
   // struct tm tm;
-  s = socket(AF_INET,SOCK_DGRAM,0);
-  if ( s == -1 ) {
+  socket_instance = socket(AF_INET,SOCK_DGRAM,0);
+  if ( socket_instance == -1 ) {
     ACA_LOG_ERROR("%d\n",errno);
   }
   memset(&portList,0,sizeof portList);
@@ -207,27 +207,20 @@ void start_upd_listener(uint oam_port_number){
 
   len_inet = sizeof portList;
 
-  z = bind(s, (struct sockaddr *)&portList, len_inet);
-  if ( z == -1 ) {
+  packet_length = bind(socket_instance, (struct sockaddr *)&portList, len_inet);
+  if ( packet_length == -1 ) {
     ACA_LOG_ERROR("%d\n",errno);
   }
 
   for (;;) {
-    z = recv(s, dgram, sizeof dgram, 0);
-    if ( z < 0 ) {
+    packet_length = recv(socket_instance, packet_content, sizeof packet_content, 0);
+    if ( packet_length < 0 ) {
       ACA_LOG_ERROR("%d\n",errno);
     }
-    ACA_LOG_INFO("Z is %d", z);
+    ACA_LOG_INFO("Packet length is %d\n", packet_length);
     ACA_LOG_INFO("Got this udp packet when listening to port %d\n", oam_port_number);
-    ACA_LOG_INFO("dgram content: %s\n", dgram);
-    std::cout << dgram << std::endl;
-    ACA_OVS_Control::get_instance().print_payload(reinterpret_cast<const unsigned char *>(dgram), z);
-    std::cout << "Printing char by char: " << std::endl;
-    for (uint i = 0 ; i < strlen(dgram); i++){
-      std::cout << dgram[i];
-    }
-    std::cout << "\nThis is the end" << std::endl;
-    aca_zeta_oam_server::ACA_Zeta_Oam_Server::get_instance().oams_recv((uint32_t)oam_port_number, dgram);
+    ACA_OVS_Control::get_instance().print_payload(reinterpret_cast<const unsigned char *>(packet_content), packet_length);
+    aca_zeta_oam_server::ACA_Zeta_Oam_Server::get_instance().oams_recv((uint32_t)oam_port_number, packet_content);
   }
 }
 int ACA_Zeta_Programming::create_zeta_config(const alcor::schema::AuxGateway current_AuxGateway,

--- a/src/zeta/aca_zeta_programming.cpp
+++ b/src/zeta/aca_zeta_programming.cpp
@@ -217,9 +217,10 @@ void start_upd_listener(uint oam_port_number){
     if ( z < 0 ) {
       ACA_LOG_ERROR("%d\n",errno);
     }
+    ACA_LOG_INFO("Z is %d", z);
     ACA_LOG_INFO("Got this udp packet when listening to port %d\n", oam_port_number);
     ACA_LOG_INFO("dgram content: %s\n", dgram);
-
+    std::cout << dgram << std::endl;
     aca_zeta_oam_server::ACA_Zeta_Oam_Server::get_instance().oams_recv((uint32_t)oam_port_number, dgram);
   }
 }

--- a/src/zeta/aca_zeta_programming.cpp
+++ b/src/zeta/aca_zeta_programming.cpp
@@ -187,7 +187,7 @@ uint ACA_Zeta_Programming::get_oam_port(string zeta_gateway_id)
   return oam_port;
 }
 void start_upd_listener(uint oam_port_number){
-  ACA_LOG_INFO("Starting a listener for port %d", oam_port_number);
+  ACA_LOG_INFO("Starting a listener for port %d\n", oam_port_number);
   int z;
   struct sockaddr_in portList;
   int len_inet;
@@ -197,7 +197,7 @@ void start_upd_listener(uint oam_port_number){
   // struct tm tm;
   s = socket(AF_INET,SOCK_DGRAM,0);
   if ( s == -1 ) {
-    strerror(errno);
+    ACA_LOG_ERROR("%d\n",errno);
   }
   memset(&portList,0,sizeof portList);
   portList.sin_family = AF_INET;
@@ -209,16 +209,16 @@ void start_upd_listener(uint oam_port_number){
 
   z = bind(s, (struct sockaddr *)&portList, len_inet);
   if ( z == -1 ) {
-    strerror(errno);
+    ACA_LOG_ERROR("%d\n",errno);
   }
 
   for (;;) {
     z = recv(s, dgram, sizeof dgram, 0);
     if ( z < 0 ) {
-      strerror(errno);
+      ACA_LOG_ERROR("%d\n",errno);
     }
-    ACA_LOG_INFO("Got this udp packet when listening to port %d", oam_port_number);
-    ACA_LOG_INFO("%s", dgram);
+    ACA_LOG_INFO("Got this udp packet when listening to port %d\n", oam_port_number);
+    ACA_LOG_INFO("dgram content: %s\n", dgram);
 
     aca_zeta_oam_server::ACA_Zeta_Oam_Server::get_instance().oams_recv((uint32_t)oam_port_number, dgram);
   }

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -350,6 +350,7 @@ TEST(zeta_programming_test_cases, DISABLED_zeta_scale_CHILD)
   // construct the GoalState from the json file
   string zeta_gateway_path_CHILD_config_file = "./test/gtest/aca_data.json";
   aca_test_zeta_setup(zeta_gateway_path_CHILD_config_file);
+  sleep(120);
   // restore demo mode
   g_demo_mode = previous_demo_mode;
 }
@@ -376,6 +377,7 @@ TEST(zeta_programming_test_cases, DISABLED_zeta_scale_PARENT)
   // construct the GoalState from the json file
   string zeta_gateway_path_CHILD_config_file = "./test/gtest/aca_data.json";
   aca_test_zeta_setup(zeta_gateway_path_CHILD_config_file);
+  sleep(120);
   // restore demo mode
   g_demo_mode = previous_demo_mode;
 }


### PR DESCRIPTION
This PR is created to replace the existing `_create_oam_ofp ` with a new thread, which listens to the `oam_port` and calls the `oams_recv` with the packet info received. 

This PR achieves the following:
1. When user runs `DISABLED_zeta_scale_PARENT`/`DISABLED_zeta_scale_CHILD` with Zeta already setup, and a correct `./test/gtest/aca_data.json`, it starts a new thread that listens to the `oam_port` for 120 seconds, before it dies.
2. When the thread receives a packet, it prints out the packet and then calls the `oams_recv`.

Part of output when doing a `ping -I port_1 -c1 port_2`, when a ping packets traversed through the Zeta gateway successfully, the OAM packet will come down and will be captured below:
```
Packet length is 44
Got this udp packet when listening to port 8300
00000   00 00 00 00 7b 00 00 02  7b 00 00 01 00 00 00 00    ....{...{.......
00016   01 00 03 78 7b 00 00 01  c0 a8 14 5d 6c dd ee 00    ...x{......]l...
00032   00 01 e8 bd d1 01 72 c8  00 1e 00 00                ......r.....
```