### PR TITLE
[Zeta] Added more details on for direct path programming logic.

### DIFF
--- a/src/zeta/aca_zeta_oam_server.cpp
+++ b/src/zeta/aca_zeta_oam_server.cpp
@@ -255,17 +255,16 @@ int ACA_Zeta_Oam_Server::_add_direct_path(oam_match match, oam_action action)
   string source_port_cmd = "";
 
   string destination_port_cmd = "";
+  ACA_LOG_DEBUG("Detected source port: %s", match.sport);
+  ACA_LOG_DEBUG("Detected destination port: %s", match.dport);
 
   if (match.sport != "0"){
-    destination_port_cmd = ",tp_src" + match.sport;
+    destination_port_cmd = ",tp_src=" + match.sport;
   }
 
   if (match.dport != "0"){
-    source_port_cmd = ",tp_dst" + match.dport;
+    source_port_cmd = ",tp_dst=" + match.dport;
   }
-
-
-
 
   string cmd_match = "ip,nw_proto=" + match.proto + ",nw_src=" + match.sip +
                      ",nw_dst=" + match.dip + source_port_cmd +

--- a/src/zeta/aca_zeta_oam_server.cpp
+++ b/src/zeta/aca_zeta_oam_server.cpp
@@ -255,8 +255,8 @@ int ACA_Zeta_Oam_Server::_add_direct_path(oam_match match, oam_action action)
   string source_port_cmd = "";
 
   string destination_port_cmd = "";
-  ACA_LOG_DEBUG("Detected source port: %s", match.sport);
-  ACA_LOG_DEBUG("Detected destination port: %s", match.dport);
+  std::cout << "Detected source port: " << match.sport << std::endl;
+  std::cout << "Detected destination port: " << match.dport << std::endl;
 
   if (match.sport != "0"){
     destination_port_cmd = ",tp_src=" + match.sport;

--- a/src/zeta/aca_zeta_oam_server.cpp
+++ b/src/zeta/aca_zeta_oam_server.cpp
@@ -255,8 +255,6 @@ int ACA_Zeta_Oam_Server::_add_direct_path(oam_match match, oam_action action)
   string source_port_cmd = "";
 
   string destination_port_cmd = "";
-  std::cout << "Detected source port: " << match.sport << std::endl;
-  std::cout << "Detected destination port: " << match.dport << std::endl;
 
   if (match.sport != "0"){
     destination_port_cmd = ",tp_src=" + match.sport;

--- a/src/zeta/aca_zeta_oam_server.cpp
+++ b/src/zeta/aca_zeta_oam_server.cpp
@@ -252,9 +252,24 @@ int ACA_Zeta_Oam_Server::_add_direct_path(oam_match match, oam_action action)
   string vlan_id = to_string(aca_vlan_manager::ACA_Vlan_Manager::get_instance().get_or_create_vlan_id(
           match.vni));
 
+  string source_port_cmd = "";
+
+  string destination_port_cmd = "";
+
+  if (match.sport != "0"){
+    destination_port_cmd = ",tp_src" + match.sport;
+  }
+
+  if (match.dport != "0"){
+    source_port_cmd = ",tp_dst" + match.dport;
+  }
+
+
+
+
   string cmd_match = "ip,nw_proto=" + match.proto + ",nw_src=" + match.sip +
-                     ",nw_dst=" + match.dip + ",tp_src=" + match.sport +
-                     ",tp_dst=" + match.dport + ",dl_vlan=" + vlan_id;
+                     ",nw_dst=" + match.dip + source_port_cmd +
+                     destination_port_cmd + ",dl_vlan=" + vlan_id;
   string cmd_action = ",actions=\"strip_vlan,load:" + to_string(match.vni) +
                       "->NXM_NX_TUN_ID[],set_field:" + action.node_nw_dst +
                       "->tun_dst,mod_dl_dst=" + action.inst_dl_dst +


### PR DESCRIPTION
The purpose of this PR is to add more details for the direct path. 

Proof of ping request went through the direct path:

Before rule is set up:
```
~$ sudo ovs-ofctl dump-flows br-tun
 cookie=0x0, duration=3.174s, table=0, n_packets=29, n_bytes=3608, priority=1,in_port="patch-int" actions=resubmit(,2)
 cookie=0x0, duration=3.133s, table=0, n_packets=0, n_bytes=0, priority=25,in_port="vxlan-generic" actions=resubmit(,4)
 cookie=0x0, duration=3.186s, table=0, n_packets=0, n_bytes=0, priority=0 actions=NORMAL
 cookie=0x0, duration=3.157s, table=2, n_packets=0, n_bytes=0, priority=25,arp,in_port="patch-int",arp_op=1 actions=resubmit(,51)
 cookie=0x0, duration=3.149s, table=2, n_packets=0, n_bytes=0, priority=25,icmp,in_port="patch-int",icmp_type=8 actions=resubmit(,52)
 cookie=0x0, duration=3.169s, table=2, n_packets=0, n_bytes=0, priority=1,dl_dst=00:00:00:00:00:00/01:00:00:00:00:00 actions=resubmit(,20)
 cookie=0x0, duration=3.165s, table=2, n_packets=29, n_bytes=3608, priority=1,dl_dst=01:00:00:00:00:00/01:00:00:00:00:00 actions=resubmit(,22)
 cookie=0x0, duration=3.107s, table=4, n_packets=0, n_bytes=0, priority=1,tun_id=0x378 actions=mod_vlan_vid:1,output:"patch-int"
 cookie=0x0, duration=3.161s, table=20, n_packets=0, n_bytes=0, priority=1 actions=resubmit(,22)
 cookie=0x0, duration=3.075s, table=22, n_packets=27, n_bytes=3464, priority=50,dl_vlan=1 actions=strip_vlan,load:0x378->NXM_NX_TUN_ID[],group:1
 cookie=0x0, duration=3.153s, table=51, n_packets=0, n_bytes=0, priority=1 actions=resubmit(,22)
 cookie=0x0, duration=3.144s, table=52, n_packets=0, n_bytes=0, priority=1 actions=resubmit(,20)
```

After the first ping, direct path was set up, but no traffic went through:
```
~$ ping -I 123.0.0.2 -c1 123.0.0.1
PING 123.0.0.1 (123.0.0.1) from 123.0.0.2 : 56(84) bytes of data.
64 bytes from 123.0.0.1: icmp_seq=1 ttl=64 time=2.06 ms

--- 123.0.0.1 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 2.069/2.069/2.069/0.000 ms
~$ sudo ovs-ofctl dump-flows br-tun
 cookie=0x0, duration=12.973s, table=0, n_packets=41, n_bytes=5094, priority=1,in_port="patch-int" actions=resubmit(,2)
 cookie=0x0, duration=12.932s, table=0, n_packets=2, n_bytes=140, priority=25,in_port="vxlan-generic" actions=resubmit(,4)
 cookie=0x0, duration=12.985s, table=0, n_packets=0, n_bytes=0, priority=0 actions=NORMAL
 cookie=0x0, duration=12.956s, table=2, n_packets=1, n_bytes=42, priority=25,arp,in_port="patch-int",arp_op=1 actions=resubmit(,51)
 cookie=0x0, duration=12.948s, table=2, n_packets=1, n_bytes=98, priority=25,icmp,in_port="patch-int",icmp_type=8 actions=resubmit(,52)
 cookie=0x0, duration=12.968s, table=2, n_packets=0, n_bytes=0, priority=1,dl_dst=00:00:00:00:00:00/01:00:00:00:00:00 actions=resubmit(,20)
 cookie=0x0, duration=12.964s, table=2, n_packets=39, n_bytes=4954, priority=1,dl_dst=01:00:00:00:00:00/01:00:00:00:00:00 actions=resubmit(,22)
 cookie=0x0, duration=12.906s, table=4, n_packets=2, n_bytes=140, priority=1,tun_id=0x378 actions=mod_vlan_vid:1,output:"patch-int"
 cookie=0x0, duration=6.049s, table=20, n_packets=0, n_bytes=0, idle_timeout=7680, priority=50,icmp,dl_vlan=1,nw_src=123.0.0.2,nw_dst=123.0.0.1 actions=strip_vlan,load:0x378->NXM_NX_TUN_ID[],load:0xc0a8145d->NXM_NX_TUN_IPV4_DST[],mod_dl_dst:6c:dd:ee:00:00:01,mod_nw_dst:123.0.0.1,output:"vxlan-generic"
 cookie=0x0, duration=12.960s, table=20, n_packets=1, n_bytes=98, priority=1 actions=resubmit(,22)
 cookie=0x0, duration=12.874s, table=22, n_packets=39, n_bytes=4950, priority=50,dl_vlan=1 actions=strip_vlan,load:0x378->NXM_NX_TUN_ID[],group:1
 cookie=0x0, duration=12.952s, table=51, n_packets=1, n_bytes=42, priority=1 actions=resubmit(,22)
 cookie=0x0, duration=12.943s, table=52, n_packets=1, n_bytes=98, priority=1 actions=resubmit(,20)
```

After the second ping, we can see traffic went through the direct path, as the `n_packets` for line of this direct path incremented by one.
```
~$ ping -I 123.0.0.2 -c1 123.0.0.1
PING 123.0.0.1 (123.0.0.1) from 123.0.0.2 : 56(84) bytes of data.
64 bytes from 123.0.0.1: icmp_seq=1 ttl=64 time=0.788 ms

--- 123.0.0.1 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.788/0.788/0.788/0.000 ms
~$ sudo ovs-ofctl dump-flows br-tun
 cookie=0x0, duration=33.670s, table=0, n_packets=48, n_bytes=5720, priority=1,in_port="patch-int" actions=resubmit(,2)
 cookie=0x0, duration=33.629s, table=0, n_packets=3, n_bytes=238, priority=25,in_port="vxlan-generic" actions=resubmit(,4)
 cookie=0x0, duration=33.682s, table=0, n_packets=0, n_bytes=0, priority=0 actions=NORMAL
 cookie=0x0, duration=33.653s, table=2, n_packets=1, n_bytes=42, priority=25,arp,in_port="patch-int",arp_op=1 actions=resubmit(,51)
 cookie=0x0, duration=33.645s, table=2, n_packets=2, n_bytes=196, priority=25,icmp,in_port="patch-int",icmp_type=8 actions=resubmit(,52)
 cookie=0x0, duration=33.665s, table=2, n_packets=0, n_bytes=0, priority=1,dl_dst=00:00:00:00:00:00/01:00:00:00:00:00 actions=resubmit(,20)
 cookie=0x0, duration=33.661s, table=2, n_packets=45, n_bytes=5482, priority=1,dl_dst=01:00:00:00:00:00/01:00:00:00:00:00 actions=resubmit(,22)
 cookie=0x0, duration=33.603s, table=4, n_packets=3, n_bytes=238, priority=1,tun_id=0x378 actions=mod_vlan_vid:1,output:"patch-int"
 cookie=0x0, duration=26.746s, table=20, n_packets=1, n_bytes=98, idle_timeout=7680, priority=50,icmp,dl_vlan=1,nw_src=123.0.0.2,nw_dst=123.0.0.1 actions=strip_vlan,load:0x378->NXM_NX_TUN_ID[],load:0xc0a8145d->NXM_NX_TUN_IPV4_DST[],mod_dl_dst:6c:dd:ee:00:00:01,mod_nw_dst:123.0.0.1,output:"vxlan-generic"
 cookie=0x0, duration=33.657s, table=20, n_packets=1, n_bytes=98, priority=1 actions=resubmit(,22)
 cookie=0x0, duration=33.571s, table=22, n_packets=45, n_bytes=5478, priority=50,dl_vlan=1 actions=strip_vlan,load:0x378->NXM_NX_TUN_ID[],group:1
 cookie=0x0, duration=33.649s, table=51, n_packets=1, n_bytes=42, priority=1 actions=resubmit(,22)
 cookie=0x0, duration=33.640s, table=52, n_packets=2, n_bytes=196, priority=1 actions=resubmit(,20)
``` 
