### PR TITLE
[Zeta] clean up oam cache and OVS code

### DIFF
--- a/include/aca_zeta_oam_server.h
+++ b/include/aca_zeta_oam_server.h
@@ -87,9 +87,7 @@ class ACA_Zeta_Oam_Server {
 
   static ACA_Zeta_Oam_Server &get_instance();
   void oams_recv(uint32_t udp_dport, void *message);
-  bool lookup_oam_port_in_cache(uint port_number);
-  void add_oam_port_cache(uint port_number);
-
+  
   private:
   uint8_t _get_message_type(oam_message *oammsg);
   string _get_mac_addr(uint8_t *mac);

--- a/include/aca_zeta_oam_server.h
+++ b/include/aca_zeta_oam_server.h
@@ -87,7 +87,7 @@ class ACA_Zeta_Oam_Server {
 
   static ACA_Zeta_Oam_Server &get_instance();
   void oams_recv(uint32_t udp_dport, void *message);
-  
+
   private:
   uint8_t _get_message_type(oam_message *oammsg);
   string _get_mac_addr(uint8_t *mac);
@@ -107,9 +107,6 @@ class ACA_Zeta_Oam_Server {
 
   void (aca_zeta_oam_server::ACA_Zeta_Oam_Server ::*_parse_oam_msg_ops[OAM_MSG_MAX])(
           uint32_t udp_dpost, oam_message *oammsg);
-
-  //  hashtable <key: oam_port, value: int *(not used)>
-  CTSL::HashMap<uint, int *> _oam_ports_cache;
 };
 } // namespace aca_zeta_oam_server
 #endif // #ifndef ACA_Zeta_OAM_SERVER_H

--- a/include/aca_zeta_programming.h
+++ b/include/aca_zeta_programming.h
@@ -68,8 +68,6 @@ class ACA_Zeta_Programming {
 
   int delete_zeta_config(const alcor::schema::AuxGateway current_AuxGateway, uint tunnel_id);
 
-  bool oam_port_rule_exists(uint port_number);
-
   bool group_rule_exists(uint group_id);
 
   uint get_oam_port(string zeta_gateway_id);
@@ -77,9 +75,6 @@ class ACA_Zeta_Programming {
   uint get_group_id(string zeta_gateway_id);
 
   private:
-  int _create_oam_ofp(uint port_number);
-  int _delete_oam_ofp(uint port_number);
-
   int _create_group_punt_rule(uint tunnel_id, uint group_id);
   int _delete_group_punt_rule(uint tunnel_id);
 

--- a/src/ovs/aca_ovs_control.cpp
+++ b/src/ovs/aca_ovs_control.cpp
@@ -264,13 +264,6 @@ void ACA_OVS_Control::parse_packet(uint32_t in_port, void *packet)
         aca_dhcp_server::ACA_Dhcp_Server::get_instance().dhcps_recv(
                 in_port, const_cast<unsigned char *>(payload));
       }
-
-      /* oam message procedure */
-      if (aca_zeta_oam_server::ACA_Zeta_Oam_Server::get_instance().lookup_oam_port_in_cache((uint)udp_dport)) {
-        ACA_LOG_INFO("%s", "   Message Type: OAM\n");
-        aca_zeta_oam_server::ACA_Zeta_Oam_Server::get_instance().oams_recv(
-                (uint32_t)udp_dport, const_cast<unsigned char *>(payload));
-      }
     }
   }
 }

--- a/src/zeta/aca_zeta_oam_server.cpp
+++ b/src/zeta/aca_zeta_oam_server.cpp
@@ -136,7 +136,7 @@ uint ACA_Zeta_Oam_Server::_get_tunnel_id(uint8_t *vni)
 
   // Convert tunnel_id to uint
   // from uint8[3] to uint
-  tunnel_id = ((uint)vni[0]) << 16 | ((uint)vni[1]) << 8 | ((uint) vni[2]);
+  tunnel_id = ((uint)vni[0]) << 16 | ((uint)vni[1]) << 8 | ((uint)vni[2]);
 
   return tunnel_id;
 }
@@ -256,11 +256,11 @@ int ACA_Zeta_Oam_Server::_add_direct_path(oam_match match, oam_action action)
 
   string destination_port_cmd = "";
 
-  if (match.sport != "0"){
+  if (match.sport != "0") {
     destination_port_cmd = ",tp_src=" + match.sport;
   }
 
-  if (match.dport != "0"){
+  if (match.dport != "0") {
     source_port_cmd = ",tp_dst=" + match.dport;
   }
 
@@ -309,19 +309,4 @@ int ACA_Zeta_Oam_Server::_del_direct_path(oam_match match)
   return overall_rc;
 }
 
-// add oam port number to cache
-void ACA_Zeta_Oam_Server::add_oam_port_cache(uint port_number)
-{
-  int *not_used;
-  if (!_oam_ports_cache.find(port_number, not_used)) {
-    _oam_ports_cache.insert(port_number, nullptr);
-  }
-}
-
-// find the oam port number in the cache
-bool ACA_Zeta_Oam_Server::lookup_oam_port_in_cache(uint port_number)
-{
-  int *not_used;
-  return _oam_ports_cache.find(port_number, not_used);
-}
 } // namespace aca_zeta_oam_server

--- a/src/zeta/aca_zeta_programming.cpp
+++ b/src/zeta/aca_zeta_programming.cpp
@@ -144,6 +144,7 @@ uint ACA_Zeta_Programming::get_oam_port(string zeta_gateway_id)
   ACA_LOG_DEBUG("ACA_Zeta_Programming::get_oam_port <--- Exiting, oam_port = %d\n", oam_port);
   return oam_port;
 }
+
 void start_upd_listener(uint oam_port_number)
 {
   ACA_LOG_INFO("Starting a listener for port %d\n", oam_port_number);
@@ -181,6 +182,7 @@ void start_upd_listener(uint oam_port_number)
             (uint32_t)oam_port_number, packet_content);
   }
 }
+
 int ACA_Zeta_Programming::create_zeta_config(const alcor::schema::AuxGateway current_AuxGateway,
                                              uint tunnel_id)
 {


### PR DESCRIPTION
#197 
1. Clean up oam cache and OVS code.
2. Fixed the error in uint ACA_Zeta_Programming::get_group_id(string zeta_gateway_id).
3. Passed all the tests in my environment.
```
[       OK ] zeta_programming_test_cases.DISABLED_zeta_scale_CHILD (120537 ms)
[----------] 1 test from zeta_programming_test_cases (120537 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (120537 ms total)
[  PASSED  ] 1 test.
```

```
[       OK ] zeta_programming_test_cases.create_auxgateway_test (329 ms)
[----------] 3 tests from zeta_programming_test_cases (369 ms total)

[----------] Global test environment tear-down
[==========] 41 tests from 8 test suites ran. (7104 ms total)
[  PASSED  ] 41 tests.

  YOU HAVE 12 DISABLED TESTS
```