### PR TITLE
[Zeta] Updated Pseudo Controller with new test case to replace the internal port testcases; added back locks to address concurrency issue.

### DIFF
--- a/include/aca_vlan_manager.h
+++ b/include/aca_vlan_manager.h
@@ -77,7 +77,8 @@ class ACA_Vlan_Manager {
 
   // CTSL::HashMap <key: tunnel ID, value: vpc_table_entry>
   CTSL::HashMap<uint, vpc_table_entry *> _vpcs_table;
-
+  // mutex for reading and writing to _vpcs_table
+  mutex _vpcs_table_mutex;
   void create_entry(uint tunnel_id);
 };
 } // namespace aca_vlan_manager

--- a/src/ovs/aca_vlan_manager.cpp
+++ b/src/ovs/aca_vlan_manager.cpp
@@ -72,12 +72,13 @@ uint ACA_Vlan_Manager::get_or_create_vlan_id(uint tunnel_id)
   ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::get_or_create_vlan_id ---> Entering\n");
 
   vpc_table_entry *new_vpc_table_entry = nullptr;
-
+  _vpcs_table_mutex.lock();
   if (!_vpcs_table.find(tunnel_id, new_vpc_table_entry)) {
     create_entry(tunnel_id);
 
     _vpcs_table.find(tunnel_id, new_vpc_table_entry);
   }
+  _vpcs_table_mutex.unlock();
   uint acquired_vlan_id = new_vpc_table_entry->vlan_id;
 
   ACA_LOG_DEBUG("%s", "ACA_Vlan_Manager::get_or_create_vlan_id <--- Exiting\n");

--- a/src/ovs/aca_vlan_manager.cpp
+++ b/src/ovs/aca_vlan_manager.cpp
@@ -93,6 +93,7 @@ int ACA_Vlan_Manager::create_ovs_port(string /*vpc_id*/, string ovs_port,
   vpc_table_entry *current_vpc_table_entry;
   int overall_rc = EXIT_FAILURE;
 
+  _vpcs_table_mutex.lock();
   bool vpc_table_entry_found = _vpcs_table.find(tunnel_id, current_vpc_table_entry);
 
   if (!vpc_table_entry_found) {
@@ -103,6 +104,7 @@ int ACA_Vlan_Manager::create_ovs_port(string /*vpc_id*/, string ovs_port,
     // create_entry(tunnel_id) above and the _vpcs_table.find below
     vpc_table_entry_found = _vpcs_table.find(tunnel_id, current_vpc_table_entry);
   }
+  _vpcs_table_mutex.unlock();
 
   if (vpc_table_entry_found) {
     // first port in the VPC will add the below rule:

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -121,7 +121,7 @@ void create_container(string container_name, string vip_address, string vmac_add
             << ", VIP: " << vip_address << ", VMAC: " << vmac_address << std::endl;
   int overall_rc = 0;
   string create_container_cmd =
-          "docker run -itd --name " + container_name + " --net=none itsthenetwork/alpine-tcpdump sh";
+          "docker run -itd --name " + container_name + " --net=none busybox sh";
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(create_container_cmd);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   string cmd_string_assign_ip_mac =

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -121,7 +121,7 @@ void create_container(string container_name, string vip_address, string vmac_add
             << ", VIP: " << vip_address << ", VMAC: " << vmac_address << std::endl;
   int overall_rc = 0;
   string create_container_cmd =
-          "docker run -itd --name " + container_name + " --net=none busybox sh";
+          "docker run -itd --name " + container_name + " --net=none itsthenetwork/alpine-tcpdump sh";
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(create_container_cmd);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   string cmd_string_assign_ip_mac =

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -120,8 +120,8 @@ void create_container(string container_name, string vip_address, string vmac_add
   std::cout << "Creating container with name: " << container_name
             << ", VIP: " << vip_address << ", VMAC: " << vmac_address << std::endl;
   int overall_rc = 0;
-  string create_container_cmd =
-          "docker run -itd --name " + container_name + " --net=none busybox sh";
+  string create_container_cmd = "docker run -itd --name " + container_name +
+                                " --net=none --label test=zeta busybox sh";
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(create_container_cmd);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
 

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -203,8 +203,6 @@ void aca_test_zeta_setup_container(string zeta_gateway_path_config_file)
           new_subnet_states, zeta_data["vpc_response"]);
 
   nlohmann::json port_response_array = zeta_data["port_response"];
-  std::vector<string> container_names;
-  std::vector<string> vip_on_other_host;
 
   for (nlohmann::json::iterator it = port_response_array.begin();
        it != port_response_array.end(); ++it) {
@@ -221,10 +219,6 @@ void aca_test_zeta_setup_container(string zeta_gateway_path_config_file)
       // create containers
       string container_name = "con-" + vip;
       create_container(container_name, vip, vmac);
-      container_names.push_back(container_name);
-    } else {
-      // add this vip to vip_on_other_host for pinging later;
-      vip_on_other_host.push_back(vip);
     }
   }
 
@@ -232,19 +226,6 @@ void aca_test_zeta_setup_container(string zeta_gateway_path_config_file)
   overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
           GoalState_builder, gsOperationalReply);
   ASSERT_EQ(overall_rc, EXIT_SUCCESS);
-
-  // do the ping
-  for (auto &other_ip : vip_on_other_host) {
-    std::cout << "Should ping vip: " + other_ip << std::endl;
-  }
-
-  std::cout << "After ping, should remove containers." << std::endl;
-  // kill the docker instances at the end.
-  // for (auto &container_name : container_names){
-  //   string rm_container_string = "docker rm -f "+container_name;
-  //   overall_rc = Aca_Net_Config::get_instance().execute_system_command(rm_container_string);
-  //   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
-  // }
 }
 
 void aca_test_zeta_setup(string zeta_gateway_path_config_file)

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -126,7 +126,7 @@ void create_container(string container_name, string vip_address, string vmac_add
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
 
   string cmd_string_assign_ip_mac =
-          "ovs-docker add-port br-int eth0" + container_name +
+          "ovs-docker add-port br-int eth0 " + container_name +
           " --ipaddress=" + vip_address + "/16 --macaddress=" + vmac_address;
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string_assign_ip_mac);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -226,8 +226,6 @@ void aca_test_zeta_setup_container(string zeta_gateway_path_config_file)
     }
   }
 
-
-
   GoalStateOperationReply gsOperationalReply;
   overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
           GoalState_builder, gsOperationalReply);
@@ -240,11 +238,11 @@ void aca_test_zeta_setup_container(string zeta_gateway_path_config_file)
 
   std::cout << "After ping, should remove containers." << std::endl;
   // kill the docker instances at the end.
-  for (auto &container_name : container_names){
-    string rm_container_string = "docker rm -f "+container_name;
-    overall_rc = Aca_Net_Config::get_instance().execute_system_command(rm_container_string);
-    EXPECT_EQ(overall_rc, EXIT_SUCCESS);
-  }
+  // for (auto &container_name : container_names){
+  //   string rm_container_string = "docker rm -f "+container_name;
+  //   overall_rc = Aca_Net_Config::get_instance().execute_system_command(rm_container_string);
+  //   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  // }
 }
 
 

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -25,7 +25,6 @@
 #include <nlohmann/json.hpp>
 #include <iostream>
 #include <typeinfo>
-// #include <vector>
 
 using namespace std;
 using namespace aca_comm_manager;

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -34,7 +34,6 @@ using namespace aca_zeta_programming;
 using namespace aca_ovs_l2_programmer;
 using namespace aca_net_config;
 
-
 extern string vmac_address_1;
 extern string vmac_address_2;
 extern string vmac_address_3;
@@ -116,19 +115,22 @@ void aca_test_create_default_subnet_state_with_zeta_data(SubnetState *new_subnet
   SubnetConiguration_builder->set_allocated_gateway(subnetConfig_GatewayBuilder);
 }
 
-void create_container(string container_name, string vip_address, string vmac_address){
-  std::cout<< "Creating container with name: "<< container_name << ", VIP: "<<vip_address<<", VMAC: "<<vmac_address << std::endl;
+void create_container(string container_name, string vip_address, string vmac_address)
+{
+  std::cout << "Creating container with name: " << container_name
+            << ", VIP: " << vip_address << ", VMAC: " << vmac_address << std::endl;
   int overall_rc = 0;
-  string create_container_cmd = "docker run -itd --name " + container_name + " --net=none busybox sh";
-  overall_rc = Aca_Net_Config::get_instance().execute_system_command(
-          create_container_cmd);
+  string create_container_cmd =
+          "docker run -itd --name " + container_name + " --net=none busybox sh";
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command(create_container_cmd);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
-  string cmd_string_assign_ip_mac = "ovs-docker add-port br-int eth0 "+container_name+" --ipaddress=" + vip_address +
-               " --macaddress=" + vmac_address;
+  string cmd_string_assign_ip_mac =
+          "ovs-docker add-port br-int eth0 " + container_name +
+          " --ipaddress=" + vip_address + "/24 --macaddress=" + vmac_address;
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string_assign_ip_mac);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
 
-  string  cmd_string_set_vlan = "ovs-docker set-vlan br-int eth0 "+container_name+" 1";
+  string cmd_string_set_vlan = "ovs-docker set-vlan br-int eth0 " + container_name + " 1";
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string_set_vlan);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
 }
@@ -189,7 +191,6 @@ void aca_test_zeta_setup_container(string zeta_gateway_path_config_file)
 
   nlohmann::json gw_array = zeta_data["vpc_response"]["gws"];
 
-
   for (nlohmann::json::iterator it = gw_array.begin(); it != gw_array.end(); ++it) {
     cout << "Filling in: " << *it << "to the destination" << endl;
     destination = auxGateway->add_destinations();
@@ -208,19 +209,19 @@ void aca_test_zeta_setup_container(string zeta_gateway_path_config_file)
        it != port_response_array.end(); ++it) {
     string ip_node = (*it)["ip_node"];
     string vip = (*it)["ips_port"][0]["ip"];
-    string vmac = (*it)["mac_port"]; 
+    string vmac = (*it)["mac_port"];
     if (aca_is_port_on_same_host(ip_node)) { //  if this ip_node is an ip on one of the interfaces on this machine ...
       cout << "IP: " << ip_node
            << " is on this same machine, add port states to it." << endl;
       PortState *new_port_states = GoalState_builder.add_port_states();
       // fill in port state structs
       aca_test_create_default_port_state_with_zeta_data(new_port_states, *it); // use 0th position for now, but need to check all ports on this host.
-      
+
       // create containers
       string container_name = "con-" + vip;
       create_container(container_name, vip, vmac);
       container_names.push_back(container_name);
-    }else{
+    } else {
       // add this vip to vip_on_other_host for pinging later;
       vip_on_other_host.push_back(vip);
     }
@@ -232,8 +233,8 @@ void aca_test_zeta_setup_container(string zeta_gateway_path_config_file)
   ASSERT_EQ(overall_rc, EXIT_SUCCESS);
 
   // do the ping
-  for (auto &other_ip : vip_on_other_host){
-    std::cout<< "Should ping vip: " + other_ip << std::endl;
+  for (auto &other_ip : vip_on_other_host) {
+    std::cout << "Should ping vip: " + other_ip << std::endl;
   }
 
   std::cout << "After ping, should remove containers." << std::endl;
@@ -244,7 +245,6 @@ void aca_test_zeta_setup_container(string zeta_gateway_path_config_file)
   //   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   // }
 }
-
 
 void aca_test_zeta_setup(string zeta_gateway_path_config_file)
 {
@@ -332,7 +332,6 @@ void aca_test_zeta_setup(string zeta_gateway_path_config_file)
           GoalState_builder, gsOperationalReply);
   ASSERT_EQ(overall_rc, EXIT_SUCCESS);
 }
-
 
 TEST(zeta_programming_test_cases, create_zeta_config_valid)
 {
@@ -515,7 +514,6 @@ TEST(zeta_programming_test_cases, DISABLED_zeta_scale_PARENT)
   // restore demo mode
   g_demo_mode = previous_demo_mode;
 }
-
 
 TEST(zeta_programming_test_cases, DISABLED_zeta_scale_container)
 {

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -25,12 +25,15 @@
 #include <nlohmann/json.hpp>
 #include <iostream>
 #include <typeinfo>
+// #include <vector>
 
 using namespace std;
 using namespace aca_comm_manager;
 using namespace alcor::schema;
 using namespace aca_zeta_programming;
 using namespace aca_ovs_l2_programmer;
+using namespace aca_net_config;
+
 
 extern string vmac_address_1;
 extern string vmac_address_2;
@@ -112,6 +115,138 @@ void aca_test_create_default_subnet_state_with_zeta_data(SubnetState *new_subnet
   subnetConfig_GatewayBuilder->set_mac_address(subnet1_gw_mac); // make it up
   SubnetConiguration_builder->set_allocated_gateway(subnetConfig_GatewayBuilder);
 }
+
+void create_container(string container_name, string vip_address, string vmac_address){
+  std::cout<< "Creating container with name: "<< container_name << ", VIP: "<<vip_address<<", VMAC: "<<vmac_address << std::endl;
+  int overall_rc = 0;
+  string create_container_cmd = "docker run -itd --name " + container_name + " --net=none busybox sh";
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command(
+          create_container_cmd);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  string cmd_string_assign_ip_mac = "ovs-docker add-port br-int eth0 "+container_name+" --ipaddress=" + vip_address +
+               " --macaddress=" + vmac_address;
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string_assign_ip_mac);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+
+  string  cmd_string_set_vlan = "ovs-docker set-vlan br-int eth0 "+container_name+" 1";
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string_set_vlan);
+  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+}
+
+void aca_test_zeta_setup_container(string zeta_gateway_path_config_file)
+{
+  ifstream ifs(zeta_gateway_path_config_file);
+  if (!ifs)
+    cout << zeta_gateway_path_config_file << "open error" << endl;
+
+  nlohmann::json zeta_data = nlohmann::json::parse(ifs);
+  cout << zeta_data << endl;
+  // print something to check if read json succeed
+  cout << "VPC DATA: " << endl;
+  cout << zeta_data["vpc_response"]["port_ibo"] << endl;
+  cout << zeta_data["vpc_response"]["vni"] << endl;
+  cout << zeta_data["vpc_response"]["vpc_id"] << endl;
+  cout << zeta_data["vpc_response"]["zgc_id"] << endl;
+  cout << "PORT DATA: " << endl;
+  cout << zeta_data["port_response"][0]["ip_node"] << endl;
+  cout << zeta_data["port_response"][0]["mac_port"] << endl;
+
+  int overall_rc;
+
+  // from here.
+
+  GoalState GoalState_builder;
+  VpcState *new_vpc_states = GoalState_builder.add_vpc_states();
+  SubnetState *new_subnet_states = GoalState_builder.add_subnet_states();
+
+  new_vpc_states->set_operation_type(OperationType::INFO);
+
+  // fill in vpc state structs
+  VpcConfiguration *VpcConfiguration_builder = new_vpc_states->mutable_configuration();
+  cout << "Filling in vni: " << zeta_data["vpc_response"]["vni"] << endl;
+  VpcConfiguration_builder->set_tunnel_id(zeta_data["vpc_response"]["vni"]); //vni
+  cout << "Filling in vpc_id: " << zeta_data["vpc_response"]["vpc_id"] << endl;
+  VpcConfiguration_builder->set_id(zeta_data["vpc_response"]["vpc_id"]); // vpc_id
+
+  // fill in auxgateway state structs
+  AuxGateway *auxGateway = VpcConfiguration_builder->mutable_auxiliary_gateway();
+  auxGateway->set_aux_gateway_type(AuxGatewayType::ZETA);
+  cout << "Filling in zgc_id: " << zeta_data["vpc_response"]["zgc_id"] << endl;
+
+  auxGateway->set_id(zeta_data["vpc_response"]["zgc_id"]); //zgc_id
+
+  AuxGateway_zeta *zeta_info = auxGateway->mutable_zeta_info();
+  cout << "Filling in port_ibo: " << zeta_data["vpc_response"]["port_ibo"] << endl; // should be int, not string
+
+  string port_ibo_string = zeta_data["vpc_response"]["port_ibo"];
+  uint port_ibo_unit = std::stoul(port_ibo_string, nullptr, 10);
+  cout << "uint in port_ibo: " << port_ibo_unit << endl;
+  zeta_info->set_port_inband_operation(port_ibo_unit); //port_ibo
+
+  AuxGateway_destination *destination;
+
+  cout << "Try to fill in gw ips/macs now" << endl;
+
+  nlohmann::json gw_array = zeta_data["vpc_response"]["gws"];
+
+
+  for (nlohmann::json::iterator it = gw_array.begin(); it != gw_array.end(); ++it) {
+    cout << "Filling in: " << *it << "to the destination" << endl;
+    destination = auxGateway->add_destinations();
+    destination->set_ip_address((*it)["ip"]);
+    destination->set_mac_address((*it)["mac"]);
+  }
+
+  // fill in subnet state structs
+  aca_test_create_default_subnet_state_with_zeta_data(
+          new_subnet_states, zeta_data["vpc_response"]);
+
+  nlohmann::json port_response_array = zeta_data["port_response"];
+  std::vector<string> container_names;
+  std::vector<string> vip_on_other_host;
+  for (nlohmann::json::iterator it = port_response_array.begin();
+       it != port_response_array.end(); ++it) {
+    string ip_node = (*it)["ip_node"];
+    string vip = (*it)["ips_port"][0]["ip"];
+    string vmac = (*it)["mac_port"]; 
+    if (aca_is_port_on_same_host(ip_node)) { //  if this ip_node is an ip on one of the interfaces on this machine ...
+      cout << "IP: " << ip_node
+           << " is on this same machine, add port states to it." << endl;
+      PortState *new_port_states = GoalState_builder.add_port_states();
+      // fill in port state structs
+      aca_test_create_default_port_state_with_zeta_data(new_port_states, *it); // use 0th position for now, but need to check all ports on this host.
+      
+      // create containers
+      string container_name = "con-" + vip;
+      create_container(container_name, vip, vmac);
+      container_names.push_back(container_name);
+    }else{
+      // add this vip to vip_on_other_host for pinging later;
+      vip_on_other_host.push_back(vip);
+    }
+  }
+
+
+
+  GoalStateOperationReply gsOperationalReply;
+  overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
+          GoalState_builder, gsOperationalReply);
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+
+  // do the ping
+  for (auto &other_ip : vip_on_other_host){
+    std::cout<< "Should ping vip: " + other_ip << std::endl;
+  }
+
+  std::cout << "After ping, should remove containers." << std::endl;
+  // kill the docker instances at the end.
+  for (auto &container_name : container_names){
+    string rm_container_string = "docker rm -f "+container_name;
+    overall_rc = Aca_Net_Config::get_instance().execute_system_command(rm_container_string);
+    EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+  }
+}
+
 
 void aca_test_zeta_setup(string zeta_gateway_path_config_file)
 {
@@ -199,6 +334,7 @@ void aca_test_zeta_setup(string zeta_gateway_path_config_file)
           GoalState_builder, gsOperationalReply);
   ASSERT_EQ(overall_rc, EXIT_SUCCESS);
 }
+
 
 TEST(zeta_programming_test_cases, create_zeta_config_valid)
 {
@@ -378,6 +514,33 @@ TEST(zeta_programming_test_cases, DISABLED_zeta_scale_PARENT)
   string zeta_gateway_path_CHILD_config_file = "./test/gtest/aca_data.json";
   aca_test_zeta_setup(zeta_gateway_path_CHILD_config_file);
   sleep(120);
+  // restore demo mode
+  g_demo_mode = previous_demo_mode;
+}
+
+
+TEST(zeta_programming_test_cases, DISABLED_zeta_scale_container)
+{
+  // ulong culminative_network_configuration_time = 0;
+  ulong not_care_culminative_time = 0;
+  int overall_rc = EXIT_SUCCESS;
+  // delete br-int and br-tun bridges
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-int", not_care_culminative_time, overall_rc);
+
+  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
+          "del-br br-tun", not_care_culminative_time, overall_rc);
+
+  // create and setup br-int and br-tun bridges, and their patch ports
+  overall_rc = ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
+  ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  overall_rc = EXIT_SUCCESS;
+  // set demo mode
+  bool previous_demo_mode = g_demo_mode;
+  g_demo_mode = false;
+  // construct the GoalState from the json file
+  string zeta_gateway_path_CHILD_config_file = "./test/gtest/aca_data.json";
+  aca_test_zeta_setup_container(zeta_gateway_path_CHILD_config_file);
   // restore demo mode
   g_demo_mode = previous_demo_mode;
 }

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -115,22 +115,24 @@ void aca_test_create_default_subnet_state_with_zeta_data(SubnetState *new_subnet
   SubnetConiguration_builder->set_allocated_gateway(subnetConfig_GatewayBuilder);
 }
 
-void create_container(string container_name, string vip_address, string vmac_address)
+void create_container(string container_name, string vip_address, string vmac_address, int counter)
 {
   std::cout << "Creating container with name: " << container_name
             << ", VIP: " << vip_address << ", VMAC: " << vmac_address << std::endl;
   int overall_rc = 0;
-  string create_container_cmd =
-          "docker run -itd --name " + container_name + " --net=none busybox sh";
-  overall_rc = Aca_Net_Config::get_instance().execute_system_command(create_container_cmd);
+  // string create_container_cmd =
+  //         "docker run -itd --name " + container_name + " --net=none busybox sh";
+  // overall_rc = Aca_Net_Config::get_instance().execute_system_command(create_container_cmd);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
+
   string cmd_string_assign_ip_mac =
-          "ovs-docker add-port br-int eth0 " + container_name +
-          " --ipaddress=" + vip_address + "/24 --macaddress=" + vmac_address;
+          "ovs-docker add-port br-int eth" + std::to_string(counter) + " " + container_name +
+          " --ipaddress=" + vip_address + "/16 --macaddress=" + vmac_address;
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string_assign_ip_mac);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
 
-  string cmd_string_set_vlan = "ovs-docker set-vlan br-int eth0 " + container_name + " 1";
+  string cmd_string_set_vlan = "ovs-docker set-vlan br-int eth" +
+                               std::to_string(counter) + " " + container_name + " 1";
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string_set_vlan);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
 }
@@ -205,6 +207,11 @@ void aca_test_zeta_setup_container(string zeta_gateway_path_config_file)
   nlohmann::json port_response_array = zeta_data["port_response"];
   std::vector<string> container_names;
   std::vector<string> vip_on_other_host;
+  string container_name = "con";
+  string create_container_cmd =
+          "docker run -itd --name " + container_name + " --net=none busybox sh";
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command(create_container_cmd);
+  int counter = 0;
   for (nlohmann::json::iterator it = port_response_array.begin();
        it != port_response_array.end(); ++it) {
     string ip_node = (*it)["ip_node"];
@@ -218,8 +225,8 @@ void aca_test_zeta_setup_container(string zeta_gateway_path_config_file)
       aca_test_create_default_port_state_with_zeta_data(new_port_states, *it); // use 0th position for now, but need to check all ports on this host.
 
       // create containers
-      string container_name = "con-" + vip;
-      create_container(container_name, vip, vmac);
+      // string container_name = "con-" + vip;
+      create_container(container_name, vip, vmac, counter);
       container_names.push_back(container_name);
     } else {
       // add this vip to vip_on_other_host for pinging later;

--- a/test/zeta-aca-test_controllerScript/README.md
+++ b/test/zeta-aca-test_controllerScript/README.md
@@ -17,6 +17,8 @@ There are now two ways to use the controller:
 python3 run.py total_ports_to_create number_of_ports_each_call amount_of_time_to_sleep amount_of_ports_to_send_to_aca
 ```
 
+2. If no parameters are specified, 2 ports will be created and be sent to the aca nodes, after which the ping will be performed between these two ports.
+
 ## Known Issues
 
 1. It is suggested that the total amount of ports to send to aca not to exceed 10, the reason for this is, after the data is sent to the aca nodes and the gtest are called, because of the large amount of data to process for the ACA(thus with longer time needed and more output will be produced), the pseudo controller will be 'frozen', and users may have to stop the controller by `control + c`.

--- a/test/zeta-aca-test_controllerScript/README.md
+++ b/test/zeta-aca-test_controllerScript/README.md
@@ -4,26 +4,20 @@ The pseudo controller is a python script that acts as a controller between Zeta 
 
 - Creates Zeta resources(zgc, vpc, nodes, ports, etc) by calling the Zeta Northbound APIs.
 - Sends the data needed for ACA to construct its GoalState to the ACA nodes.
-- Calls different test cases, constructs the GoalStates do some validation.
-- If the above steps are all successful, the psedu controller will execute a ping command from the parent node to the child node, in order to verify the results of the previous steps.
+- Calls test case DISABLED_zeta_scale_container, constructs the GoalStates do some validation, and start Busybox container(s), each of which has one zeta port.
+- If the above steps are all successful, the pseudo controller will execute 3 ping commands from the containers on the parent node to the containers on the child node, before it executes another 3 ping commands from containers on the child node to containers on the parent node, in order to verify the results of the previous steps.
 
 ## Usage
 
 There are now two ways to use the controller:
 
-1. To create only two ports (by default) and run the tests DISABLED_zeta_gateway_path_CHILD and DISABLED_zeta_gateway_path_PARENT, user only need to run:
+1. To create up to 1,000,000 port and run the tests DISABLED_zeta_scale_container, with flags to control how many ports to create in total, how many ports each /ports POST call should generate(up to 4,000 ports), how much time the pseudo controller sleeps after each call, and how many ports to send to the aca nodes(this also equals the total # of containers that the aca nodes will create) the user should run:
 
 ```sh
-python3 run.py
-```
-
-2. To create up to 1,000,000 port and run the tests DISABLED_zeta_scale_CHILD and DISABLED_zeta_scale_PARENT, with flags to control how many ports to create in total, how many ports each /ports POST call should generate(up to 4,000 ports), and how much time the pseudo controller sleeps after each call, the user should run:
-
-```sh
-python3 run.py total_ports_to_create number_of_ports_each_call amount_of_time_to_sleep.
+python3 run.py total_ports_to_create number_of_ports_each_call amount_of_time_to_sleep amount_of_ports_to_send_to_aca
 ```
 
 ## Known Issues
 
-1. It is suggested that the total amount of ports to create not to exceed 10,000, the reason for this is, after the data is sent to the aca nodes and the gtest are called, because of the large amount of data to process for the ACA(thus with longer time needed and more output will be produced), the pseudo controller will be 'frozen', and users may have to stop the controller by `control + c`.
+1. It is suggested that the total amount of ports to send to aca not to exceed 10, the reason for this is, after the data is sent to the aca nodes and the gtest are called, because of the large amount of data to process for the ACA(thus with longer time needed and more output will be produced), the pseudo controller will be 'frozen', and users may have to stop the controller by `control + c`.
 Please note that, even if the pseudo controller is 'frozen', it doesn't mean the gtests failed. You can execute the gtests on the aca nodes manually, and the gtests should run and you should see the results.

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -426,9 +426,9 @@ def run():
             print(
                 '************* All pings ended, time to cleanup the containers *************')
             exec_sshCommand_aca(
-                host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=f'docker rm -f {parent_node_containers_names_string}', timeout=20)
+                host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=[f'docker rm -f {parent_node_containers_names_string}'], timeout=20)
             exec_sshCommand_aca(
-                host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=f'docker rm -f {child_node_containers_names_string}', timeout=20)
+                host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=[f'docker rm -f {child_node_containers_names_string}'], timeout=20)
         else:
             print(f'Either parent or child does not have any ports, somethings wrong.')
     print('This is the end of the pseudo controller, goodbye.')

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -396,9 +396,9 @@ def run():
                 br_tun_before_ping = exec_sshCommand_aca(
                     host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
                 pinger = parent_ports[randint(0,
-                                              len(parent_ports))]["ips_port"][0]["ip"]
+                                              len(parent_ports)-1)]["ips_port"][0]["ip"]
                 pingee = child_ports[randint(0,
-                                             len(child_ports))]["ips_port"][0]["ip"]
+                                             len(child_ports)-1)]["ips_port"][0]["ip"]
 
                 ping_cmd = ["sudo ln -s /snap/bin/docker /usr/bin/docker",
                             f'docker exec con-{pinger} ping -c1 {pingee}']
@@ -407,7 +407,7 @@ def run():
                     host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=ping_cmd, timeout=20)
                 br_tun_after_ping = exec_sshCommand_aca(
                     host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
-                print(f'Ping succeeded: {ping_result["status"][0] == 0}')
+                print(f'Ping succeeded: {ping_result["status"][1] == 0}')
             print(
                 f"Doing ping from child: {aca_nodes[1]} to parent: {aca_nodes[0]}")
             for i in range(ping_times):
@@ -415,9 +415,9 @@ def run():
                 br_tun_before_ping = exec_sshCommand_aca(
                     host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
                 pinger = child_ports[randint(0,
-                                             len(child_ports))]["ips_port"][0]["ip"]
+                                             len(child_ports)-1)]["ips_port"][0]["ip"]
                 pingee = parent_ports[randint(0,
-                                              len(parent_ports))]["ips_port"][0]["ip"]
+                                              len(parent_ports)-1)]["ips_port"][0]["ip"]
 
                 ping_cmd = ["sudo ln -s /snap/bin/docker /usr/bin/docker",
                             f'docker exec con-{pinger} ping -c1 {pingee}']
@@ -426,7 +426,7 @@ def run():
                     host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=ping_cmd, timeout=20)
                 br_tun_after_ping = exec_sshCommand_aca(
                     host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
-                print(f'Ping succeeded: {ping_result["status"][0] == 0}')
+                print(f'Ping succeeded: {ping_result["status"][1] == 0}')
         else:
             print(f'Either parent or child does not have any ports, somethings wrong.')
     print('This is the end of the pseudo controller, goodbye.')

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -360,10 +360,10 @@ def run():
         result_child = future_child.result()
         result_parent = future_parent.result()
         text_file_child = open("output_child.log", "w")
-        text_file_child.write(result_child['data'])
+        text_file_child.write(result_child['data'][0])
         text_file_child.close()
         text_file_parent = open("output_parent.log", "w")
-        text_file_parent.write(result_parent['data'])
+        text_file_parent.write(result_parent['data'][0])
         text_file_parent.close()
         print("Port set up finished")
         # for status_code in result_child["status"]:
@@ -395,10 +395,10 @@ def run():
                 dump_flow_cmd = ['sudo ovs-ofctl dump-flows br-tun']
                 br_tun_before_ping = exec_sshCommand_aca(
                     host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
-                pinger = parent_ports[randint(
-                    len(parent_ports))]["ips_port"][0]["ip"]
-                pingee = child_ports[randint(
-                    len(child_ports))]["ips_port"][0]["ip"]
+                pinger = parent_ports[randint(0,
+                                              len(parent_ports))]["ips_port"][0]["ip"]
+                pingee = child_ports[randint(0,
+                                             len(child_ports))]["ips_port"][0]["ip"]
 
                 ping_cmd = ["sudo ln -s /snap/bin/docker /usr/bin/docker",
                             f'docker exec con-{pinger} ping -c1 {pingee}']
@@ -414,10 +414,10 @@ def run():
                 dump_flow_cmd = ['sudo ovs-ofctl dump-flows br-tun']
                 br_tun_before_ping = exec_sshCommand_aca(
                     host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
-                pinger = child_ports[randint(
-                    len(child_ports))]["ips_port"][0]["ip"]
-                pingee = parent_ports[randint(
-                    len(parent_ports))]["ips_port"][0]["ip"]
+                pinger = child_ports[randint(0,
+                                             len(child_ports))]["ips_port"][0]["ip"]
+                pingee = parent_ports[randint(0,
+                                              len(parent_ports))]["ips_port"][0]["ip"]
 
                 ping_cmd = ["sudo ln -s /snap/bin/docker /usr/bin/docker",
                             f'docker exec con-{pinger} ping -c1 {pingee}']

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -380,8 +380,8 @@ def run():
             pingee = child_ports[0]["ips_port"][0]["ip"]
             # ping_cmd = [
             #     f'ping -I {parent_ports[0]["ips_port"][0]["ip"]} -c1 {child_ports[0]["ips_port"][0]["ip"]}']
-            ping_cmd = [
-                f'docker exec con-{pinger} ping -c1 {pingee}']
+            ping_cmd = ["sudo ln -s /snap/bin/docker /usr/bin/docker",
+                        f'docker exec con-{pinger} ping -c1 {pingee}']
             print(f'Command for ping: {ping_cmd[0]}')
             ping_result = exec_sshCommand_aca(
                 host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=ping_cmd, timeout=20)

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -9,6 +9,7 @@ from math import ceil
 import threading
 import concurrent.futures
 import subprocess
+from random import randint
 
 server_aca_repo_path = ''
 aca_data_destination_path = '/test/gtest/aca_data.json'
@@ -373,20 +374,43 @@ def run():
             port['ip_node'].split('.'))[3] == (zeta_data['aca_nodes']['ip'][1].split('.'))[3]]
         ping_result = {}
         if len(parent_ports) > 0 and len(child_ports) > 0:
-            dump_flow_cmd = ['sudo ovs-ofctl dump-flows br-tun']
-            br_tun_before_ping = exec_sshCommand_aca(
-                host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
-            pinger = parent_ports[0]["ips_port"][0]["ip"]
-            pingee = child_ports[0]["ips_port"][0]["ip"]
-            # ping_cmd = [
-            #     f'ping -I {parent_ports[0]["ips_port"][0]["ip"]} -c1 {child_ports[0]["ips_port"][0]["ip"]}']
-            ping_cmd = ["sudo ln -s /snap/bin/docker /usr/bin/docker",
-                        f'docker exec con-{pinger} ping -c1 {pingee}']
-            print(f'Command for ping: {ping_cmd[0]}')
-            ping_result = exec_sshCommand_aca(
-                host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=ping_cmd, timeout=20)
-            br_tun_after_ping = exec_sshCommand_aca(
-                host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
+            ping_times = 3
+            print(
+                f"Doing ping from parent: {aca_nodes[0]} to child: {aca_nodes[1]}")
+            for i in range(ping_times):
+                dump_flow_cmd = ['sudo ovs-ofctl dump-flows br-tun']
+                br_tun_before_ping = exec_sshCommand_aca(
+                    host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
+                pinger = parent_ports[randint(
+                    len(parent_ports))]["ips_port"][0]["ip"]
+                pingee = child_ports[randint(
+                    len(child_ports))]["ips_port"][0]["ip"]
+
+                ping_cmd = ["sudo ln -s /snap/bin/docker /usr/bin/docker",
+                            f'docker exec con-{pinger} ping -c1 {pingee}']
+                print(f'Command for ping: {ping_cmd[0]}')
+                ping_result = exec_sshCommand_aca(
+                    host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=ping_cmd, timeout=20)
+                br_tun_after_ping = exec_sshCommand_aca(
+                    host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
+            print(
+                f"Doing ping from child: {aca_nodes[1]} to parent: {aca_nodes[0]}")
+            for i in range(ping_times):
+                dump_flow_cmd = ['sudo ovs-ofctl dump-flows br-tun']
+                br_tun_before_ping = exec_sshCommand_aca(
+                    host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
+                pinger = child_ports[randint(
+                    len(child_ports))]["ips_port"][0]["ip"]
+                pingee = parent_ports[randint(
+                    len(parent_ports))]["ips_port"][0]["ip"]
+
+                ping_cmd = ["sudo ln -s /snap/bin/docker /usr/bin/docker",
+                            f'docker exec con-{pinger} ping -c1 {pingee}']
+                print(f'Command for ping: {ping_cmd[0]}')
+                ping_result = exec_sshCommand_aca(
+                    host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=ping_cmd, timeout=20)
+                br_tun_after_ping = exec_sshCommand_aca(
+                    host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
         else:
             print(f'Either parent or child does not have any ports, somethings wrong.')
         print(f'Ping succeeded: {ping_result["status"][0] == 0}')

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -342,10 +342,19 @@ def run():
         return
     else:
         print("upload file %s successfully" % aca_data_local_path)
+        print('Before the Ping test, remove previously created containers on aca nodes, if any.')
+
+    remove_container_cmd = [
+        'docker rm -f $(docker ps --filter "label=test=zeta" -aq)']
+    aca_nodes = aca_nodes_ip
+
+    exec_sshCommand_aca(
+        host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=remove_container_cmd, timeout=20)
+    exec_sshCommand_aca(
+        host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=remove_container_cmd, timeout=20)
 
     test_start_time = time.time()
     # Execute remote command, use the transferred file to change the information in aca_test_ovs_util.cpp,recompile using 'make',perform aca_test
-    aca_nodes = aca_nodes_ip
     cmd_child = [
         f'cd {server_aca_repo_path};sudo ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*{testcases_to_run[0]}']
 
@@ -371,14 +380,6 @@ def run():
     print(
         f'Time took for the tests of ACA nodes are {test_end_time - test_start_time} seconds.')
     if execute_ping:
-        print('Before the Ping test, remove previously created containers on aca nodes, if any.')
-        remove_container_cmd = [
-            'docker rm $(docker ps --filter "label=test=zeta" -aq)']
-        exec_sshCommand_aca(
-            host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=remove_container_cmd, timeout=20)
-        exec_sshCommand_aca(
-            host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=remove_container_cmd, timeout=20)
-
         print('Time for the Ping test')
         parent_ports = [port for port in json_content_for_aca['port_response'] if (
             port['ip_node'].split('.'))[3] == (zeta_data['aca_nodes']['ip'][0].split('.'))[3]]

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -371,6 +371,14 @@ def run():
     print(
         f'Time took for the tests of ACA nodes are {test_end_time - test_start_time} seconds.')
     if execute_ping:
+        print('Before the Ping test, remove previously created containers on aca nodes, if any.')
+        remove_container_cmd = [
+            'docker rm $(docker ps --filter "label=test=zeta" -aq)']
+        exec_sshCommand_aca(
+            host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=remove_container_cmd, timeout=20)
+        exec_sshCommand_aca(
+            host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=remove_container_cmd, timeout=20)
+
         print('Time for the Ping test')
         parent_ports = [port for port in json_content_for_aca['port_response'] if (
             port['ip_node'].split('.'))[3] == (zeta_data['aca_nodes']['ip'][0].split('.'))[3]]
@@ -423,12 +431,6 @@ def run():
                 br_tun_after_ping = exec_sshCommand_aca(
                     host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
                 print(f'Ping succeeded: {ping_result["status"][0] == 0}')
-            print(
-                '************* All pings ended, time to cleanup the containers *************')
-            exec_sshCommand_aca(
-                host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=[f'docker rm -f {parent_node_containers_names_string}'], timeout=20)
-            exec_sshCommand_aca(
-                host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=[f'docker rm -f {child_node_containers_names_string}'], timeout=20)
         else:
             print(f'Either parent or child does not have any ports, somethings wrong.')
     print('This is the end of the pseudo controller, goodbye.')

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -319,6 +319,8 @@ def run():
         print(
             f'Set time interval between /nodes POST calls to be {arg3} seconds.')
 
+    ports_to_send_to_aca = 2
+
     if len(arguments) > 4:
         arg4 = int(arguments[4])
         ports_to_send_to_aca = arg4

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -17,7 +17,6 @@ aca_data_local_path = './aca_data.json'
 
 ips_ports_ip_prefix = "123."
 mac_port_prefix = "6c:dd:ee:"
-ports_to_send_to_aca = 10
 
 
 # Transfer the file locally to aca nodes
@@ -93,7 +92,7 @@ def exec_sshCommand_aca(host, user, password, cmd, timeout=60, output=True):
         return result
 
 
-def talk_to_zeta(file_path, zgc_api_url, zeta_data, port_api_upper_limit, time_interval_between_calls_in_seconds):
+def talk_to_zeta(file_path, zgc_api_url, zeta_data, port_api_upper_limit, time_interval_between_calls_in_seconds, ports_to_send_to_aca):
     headers = {'Content-type': 'application/json'}
     # create ZGC
     ZGC_data = zeta_data["ZGC_data"]
@@ -327,7 +326,7 @@ def run():
             f'Set amount of ports to sent to aca to be: {ports_to_send_to_aca}')
 
     json_content_for_aca = talk_to_zeta(file_path, zgc_api_url, zeta_data,
-                                        port_api_upper_limit, time_interval_between_calls_in_seconds)
+                                        port_api_upper_limit, time_interval_between_calls_in_seconds, ports_to_send_to_aca)
 
     if json_content_for_aca is False:
         print('Failed to talk to Zeta, pseudo controller will exit now.')

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -390,7 +390,7 @@ def run():
         if len(parent_ports) > 0 and len(child_ports) > 0:
             ping_times = 3
             print(
-                f"Doing ping from parent: {aca_nodes[0]} to child: {aca_nodes[1]}")
+                f"*************Doing ping from parent: {aca_nodes[0]} to child: {aca_nodes[1]}*************")
             for i in range(ping_times):
                 dump_flow_cmd = ['sudo ovs-ofctl dump-flows br-tun']
                 br_tun_before_ping = exec_sshCommand_aca(
@@ -400,16 +400,15 @@ def run():
                 pingee = child_ports[randint(0,
                                              len(child_ports)-1)]["ips_port"][0]["ip"]
 
-                ping_cmd = ["sudo ln -s /snap/bin/docker /usr/bin/docker",
-                            f'docker exec con-{pinger} ping -c1 {pingee}']
+                ping_cmd = [f'docker exec con-{pinger} ping -c1 {pingee}']
                 print(f'Command for ping: {ping_cmd[0]}')
                 ping_result = exec_sshCommand_aca(
                     host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=ping_cmd, timeout=20)
                 br_tun_after_ping = exec_sshCommand_aca(
                     host=aca_nodes[0], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
-                print(f'Ping succeeded: {ping_result["status"][1] == 0}')
+                print(f'Ping succeeded: {ping_result["status"][0] == 0}')
             print(
-                f"Doing ping from child: {aca_nodes[1]} to parent: {aca_nodes[0]}")
+                f"*************Doing ping from child: {aca_nodes[1]} to parent: {aca_nodes[0]}*************")
             for i in range(ping_times):
                 dump_flow_cmd = ['sudo ovs-ofctl dump-flows br-tun']
                 br_tun_before_ping = exec_sshCommand_aca(
@@ -419,14 +418,13 @@ def run():
                 pingee = parent_ports[randint(0,
                                               len(parent_ports)-1)]["ips_port"][0]["ip"]
 
-                ping_cmd = ["sudo ln -s /snap/bin/docker /usr/bin/docker",
-                            f'docker exec con-{pinger} ping -c1 {pingee}']
+                ping_cmd = [f'docker exec con-{pinger} ping -c1 {pingee}']
                 print(f'Command for ping: {ping_cmd[0]}')
                 ping_result = exec_sshCommand_aca(
                     host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=ping_cmd, timeout=20)
                 br_tun_after_ping = exec_sshCommand_aca(
                     host=aca_nodes[1], user=aca_nodes_data['username'], password=aca_nodes_data['password'], cmd=dump_flow_cmd, timeout=20)
-                print(f'Ping succeeded: {ping_result["status"][1] == 0}')
+                print(f'Ping succeeded: {ping_result["status"][0] == 0}')
         else:
             print(f'Either parent or child does not have any ports, somethings wrong.')
     print('This is the end of the pseudo controller, goodbye.')

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -8,7 +8,7 @@ import itertools
 from math import ceil
 import threading
 import concurrent.futures
-
+import subprocess
 
 server_aca_repo_path = ''
 aca_data_destination_path = '/test/gtest/aca_data.json'
@@ -262,6 +262,7 @@ def generate_ports(ports_to_create):
 
 
 def run():
+    subprocess.call(['/home/user/ws/zzxgzgz/zeta/deploy/zeta_deploy.sh', '-d',  'lab'])
     port_api_upper_limit = 1000
     time_interval_between_calls_in_seconds = 10
     ports_to_create = 2


### PR DESCRIPTION
This PR does the following:

1. Address the concurrency problem for the vpc_id inside aca.
2. Created new test case, `DISABLED_zeta_scale_container `, to replace the original `DISABLED_zeta_scale_PARENT` and `DISABLED_zeta_scale_CHILD`, as multiple internal ports are proved not working for our ping test.
3. Modified the logic for the pseudo controller according to the new test case, please refer to the updated `test/zeta-aca-test_controllerScript/README.md test/zeta-aca-test_controllerScript/README.md ` for more information.


Sample output for running the update pseudo controller:
[no_param.txt](https://github.com/futurewei-cloud/alcor-control-agent/files/5852497/no_param.txt)
[with_param.txt](https://github.com/futurewei-cloud/alcor-control-agent/files/5852498/with_param.txt)
