### PR TITLE
[Zeta] Add validation code [date:1.22]

### DIFF
--- a/include/aca_zeta_programming.h
+++ b/include/aca_zeta_programming.h
@@ -74,6 +74,8 @@ class ACA_Zeta_Programming {
 
   uint get_group_id(string zeta_gateway_id);
 
+  bool group_rule_info_correct(uint group_id,string gws_ip,string gws_mac);
+
   private:
   int _create_group_punt_rule(uint tunnel_id, uint group_id);
   int _delete_group_punt_rule(uint tunnel_id);

--- a/src/zeta/aca_zeta_programming.cpp
+++ b/src/zeta/aca_zeta_programming.cpp
@@ -466,6 +466,25 @@ bool ACA_Zeta_Programming::group_rule_exists(uint group_id)
   }
 }
 
+// Determine whether the gws_ip and gws_mac is right in group entry?
+bool ACA_Zeta_Programming::group_rule_info_correct(uint group_id, string gws_ip, string gws_mac)
+{
+  bool overall_rc;
+  // Construct query command
+  string dump_flows = "ovs-ofctl -O OpenFlow13 dump-groups br-tun";
+  string opt1 = "group_id=" + to_string(group_id);
+  const string tail = "-\\>tun_dst";
+  const string tail_mac = "-\\>eth_dst";
+  string opt2 = "bucket=actions=set_field:" + gws_ip + tail +",set_field:" + gws_mac + tail_mac + " >/dev/null 2>&1";
+  string cmd_string = dump_flows + " | grep " + opt1 + " | grep " + opt2;
+  overall_rc = aca_net_config::Aca_Net_Config::get_instance().execute_system_command(cmd_string);
+  if (overall_rc == EXIT_SUCCESS) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 uint ACA_Zeta_Programming::get_group_id(string zeta_gateway_id)
 {
   ACA_LOG_DEBUG("%s", "ACA_Zeta_Programming::get_group_id ---> Entering\n");

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -425,24 +425,6 @@ TEST(zeta_programming_test_cases, create_auxgateway_test)
   EXPECT_EQ(retcode, EXIT_SUCCESS);
 }
 
-TEST(zeta_programming_test_cases, DISABLED_zeta_gateway_path_CHILD)
-{
-  // TODO: The relative path of the CHILD configuration file
-  string zeta_gateway_path_CHILD_config_file = "./test/gtest/aca_data.json";
-  aca_test_zeta_setup(zeta_gateway_path_CHILD_config_file);
-
-  // do some validate
-}
-
-TEST(zeta_programming_test_cases, DISABLED_zeta_gateway_path_PARENT)
-{
-  // TODO: The relative path of the PARENT configuration file
-  string zeta_gateway_path_PARENT_config_file = "./test/gtest/aca_data.json";
-  aca_test_zeta_setup(zeta_gateway_path_PARENT_config_file);
-
-  // do some validate
-}
-
 TEST(zeta_programming_test_cases, DISABLED_zeta_scale_CHILD)
 {
   // ulong culminative_network_configuration_time = 0;

--- a/test/zeta-aca-test_controllerScript/data/zeta_data_sdn.json
+++ b/test/zeta-aca-test_controllerScript/data/zeta_data_sdn.json
@@ -1,0 +1,128 @@
+{
+    "zeta_api_ip": "http://172.16.50.8",
+    "aca_nodes": {
+      "ip": [
+        "172.16.50.221",
+        "172.16.50.222"
+      ],
+      "username": "***",
+      "password": "***"
+    },
+    "server_aca_repo_path": "/home/sdn/alcor-control-agent",
+    "ZGC_data": {
+      "name": "ZGC_test",
+      "description": "ZGC_test",
+      "ip_start": "172.16.150.80",
+      "ip_end": "172.16.150.95",
+      "port_ibo": "8300",
+      "overlay_type": "vxlan"
+    },
+    "VPC_data": [
+      {
+      "vpc_id": "3dda2801-d675-4688-a63f-dcda8d327f61",
+        "vni": "888"
+      }  
+    ],
+    "PORT_data": [
+      {
+        "port_id": "333d4fae-7dec-11d0-a765-00a0c9341120",
+        "vpc_id": "3dda2801-d675-4688-a63f-dcda8d327f61",
+        "ips_port": [
+          {
+            "ip": "10.10.0.92",
+            "vip": ""
+          }
+        ],
+        "mac_port": "cc:dd:ee:ff:11:22",
+        "ip_node": "172.16.150.221",
+        "mac_node": "64:6e:97:0d:80:a9"
+      },
+      {
+        "port_id": "99976feae-7dec-11d0-a765-00a0c9342230",
+        "vpc_id": "3dda2801-d675-4688-a63f-dcda8d327f61",
+        "ips_port": [
+          {
+            "ip": "10.10.0.93",
+            "vip": ""
+          }
+        ],
+        "mac_port": "6c:dd:ee:ff:11:32",
+        "ip_node": "172.16.150.222",
+        "mac_node": "64:6e:97:1c:8e:65"
+      }
+    ],
+    "NODE_data": [
+      {
+        "zgc_id": "zgc_id",
+        "description": "znode90",
+        "name": "znode90",
+        "ip_control": "172.16.50.190",
+        "id_control": "ubuntu",
+        "pwd_control": "Lab12345",
+        "inf_tenant": "ens4",
+        "mac_tenant": "52:54:00:a9:3f:b9",
+        "inf_zgc": "ens3",
+        "mac_zgc": "52:54:00:1a:cf:38"
+      },
+      {
+        "zgc_id": "zgc_id",
+        "description": "znode91",
+        "name": "znode91",
+        "ip_control": "172.16.50.191",
+        "id_control": "ubuntu",
+        "pwd_control": "Lab12345",
+        "inf_tenant": "ens4",
+        "mac_tenant": "52:54:00:69:4d:be",
+        "inf_zgc": "ens3",
+        "mac_zgc": "52:54:00:0c:1e:f9"
+      },
+      {
+        "zgc_id": "zgc_id",
+        "description": "znode92",
+        "name": "znode92",
+        "ip_control": "172.16.50.192",
+        "id_control": "ubuntu",
+        "pwd_control": "Lab12345",
+        "inf_tenant": "ens4",
+        "mac_tenant": "52:54:00:bb:47:12",
+        "inf_zgc": "ens3",
+        "mac_zgc": "52:54:00:bd:96:0b"
+      },
+      {
+        "zgc_id": "zgc_id",
+        "description": "znode93",
+        "name": "znode93",
+        "ip_control": "172.16.50.193",
+        "id_control": "ubuntu",
+        "pwd_control": "Lab12345",
+        "inf_tenant": "ens4",
+        "mac_tenant": "52:54:00:ad:3d:1c",
+        "inf_zgc": "ens3",
+        "mac_zgc": "52:54:00:f3:ba:7c"
+      },
+      {
+        "zgc_id": "zgc_id",
+        "description": "znode94",
+        "name": "znode94",
+        "ip_control": "172.16.50.194",
+        "id_control": "ubuntu",
+        "pwd_control": "Lab12345",
+        "inf_tenant": "ens4",
+        "mac_tenant": "52:54:00:b9:30:17",
+        "inf_zgc": "ens3",
+        "mac_zgc": "52:54:00:3d:27:36"
+      },
+      {
+        "zgc_id": "zgc_id",
+        "description": "znode95",
+        "name": "znode95",
+        "ip_control": "172.16.50.195",
+        "id_control": "ubuntu",
+        "pwd_control": "Lab12345",
+        "inf_tenant": "ens4",
+        "mac_tenant": "52:54:00:1e:40:5a",
+        "inf_zgc": "ens3",
+        "mac_zgc": "52:54:00:23:17:1b"
+      }
+    ]
+  }

--- a/test/zeta-aca-test_controllerScript/run.py
+++ b/test/zeta-aca-test_controllerScript/run.py
@@ -210,8 +210,10 @@ def get_port_template(i):
                 }
             ],
             "mac_port": "cc:dd:ee:ff:11:22",
-            "ip_node": "192.168.20.92",
-            "mac_node": "e8:bd:d1:01:77:ec"
+            # "ip_node": "192.168.20.92",
+            "ip_node": "172.16.150.221",
+            # "mac_node": "e8:bd:d1:01:77:ec"
+            "mac_node": "64:6e:97:0d:80:a9"
         }
     return {
         "port_id": "99976feae-7dec-11d0-a765-00a0c9342230",
@@ -223,8 +225,10 @@ def get_port_template(i):
             }
         ],
         "mac_port": "6c:dd:ee:ff:11:32",
-        "ip_node": "192.168.20.93",
-        "mac_node": "e8:bd:d1:01:72:c8"
+        # "ip_node": "192.168.20.93",
+        "ip_node": "172.16.150.222",
+        # "mac_node": "e8:bd:d1:01:72:c8"
+        "mac_node": "64:6e:97:1c:8e:65"
     }
 
 
@@ -266,15 +270,18 @@ def generate_ports(ports_to_create):
 
 
 def run():
-    subprocess.call(
-        ['/home/user/ws/zzxgzgz/zeta/deploy/zeta_deploy.sh', '-d',  'lab'])
+    # rebuild zgc nodes kvm and cleanup zeta data
+    # subprocess.call(
+    #     ['/home/user/ws/zzxgzgz/zeta/deploy/zeta_deploy.sh', '-d',  'lab'])
+
     port_api_upper_limit = 1000
     time_interval_between_calls_in_seconds = 10
     ports_to_create = 2
     # right now the only argument should be how many ports to be generated.
     arguments = sys.argv
     print(f'Arguments: {arguments}')
-    file_path = './data/zeta_data.json'
+    # file_path = './data/zeta_data.json'
+    file_path = './data/zeta_data_sdn.json'
     zeta_data = {}
     with open(file_path, 'r', encoding='utf8')as fp:
         zeta_data = json.loads(fp.read())


### PR DESCRIPTION
Verify that the group entry was added successfully and that the group entry contents are correct (gws_ip and gws_mac), Based on the latest ACA code (container port) and In the case of creating two ports, the sdn lab environment test was successful, and the test results are as follows:
```shell
ACA_Zeta_Programming::get_group_id ---> Entering
Executing command: ovs-ofctl -O OpenFlow13 dump-groups br-tun | grep group_id=1
 group_id=1,type=select,bucket=actions=set_field:172.16.150.88->tun_dst,set_field:82:83:ac:10:96:58->eth_dst,output:100,bucket=actions=set_field:172.16.150.82->tun_dst,set_field:82:83:ac:10:96:52->eth_dst,output:100,bucket=actions=set_field:172.16.150.95->tun_dst,set_field:82:83:ac:10:96:5f->eth_dst,output:100,bucket=actions=set_field:172.16.150.89->tun_dst,set_field:82:83:ac:10:96:59->eth_dst,output:100,bucket=actions=set_field:172.16.150.83->tun_dst,set_field:82:83:ac:10:96:53->eth_dst,output:100,bucket=actions=set_field:172.16.150.90->tun_dst,set_field:82:83:ac:10:96:5a->eth_dst,output:100,bucket=actions=set_field:172.16.150.84->tun_dst,set_field:82:83:ac:10:96:54->eth_dst,output:100,bucket=actions=set_field:172.16.150.91->tun_dst,set_field:82:83:ac:10:96:5b->eth_dst,output:100,bucket=actions=set_field:172.16.150.85->tun_dst,set_field:82:83:ac:10:96:55->eth_dst,output:100,bucket=actions=set_field:172.16.150.92->tun_dst,set_field:82:83:ac:10:96:5c->eth_dst,output:100,bucket=actions=set_field:172.16.150.80->tun_dst,set_field:82:83:ac:10:96:50->eth_dst,output:100,bucket=actions=set_field:172.16.150.86->tun_dst,set_field:82:83:ac:10:96:56->eth_dst,output:100,bucket=actions=set_field:172.16.150.93->tun_dst,set_field:82:83:ac:10:96:5d->eth_dst,output:100,bucket=actions=set_field:172.16.150.87->tun_dst,set_field:82:83:ac:10:96:57->eth_dst,output:100,bucket=actions=set_field:172.16.150.81->tun_dst,set_field:82:83:ac:10:96:51->eth_dst,output:100,bucket=actions=set_field:172.16.150.94->tun_dst,set_field:82:83:ac:10:96:5e->eth_dst,output:100
Command succeeded!
 Elapsed time for system command took: 1184 microseconds or 1 milliseconds.
group rule is exist!
CHILD group rule exist
Executing command: ovs-ofctl -O OpenFlow13 dump-groups br-tun | grep group_id=1 | grep bucket=actions=set_field:172.16.150.80-\>tun_dst,set_field:82:83:ac:10:96:50-\>eth_dst >/dev/null 2>&1
Command succeeded!
 Elapsed time for system command took: 1433 microseconds or 1 milliseconds.
gws_ip:172.16.150.80,gws_mac:82:83:ac:10:96:50 is in group rule.
Executing command: ovs-ofctl -O OpenFlow13 dump-groups br-tun | grep group_id=1 | grep bucket=actions=set_field:172.16.150.81-\>tun_dst,set_field:82:83:ac:10:96:51-\>eth_dst >/dev/null 2>&1
Command succeeded!
 Elapsed time for system command took: 1316 microseconds or 1 milliseconds.
gws_ip:172.16.150.81,gws_mac:82:83:ac:10:96:51 is in group rule.

......

Executing command: ovs-ofctl -O OpenFlow13 dump-groups br-tun | grep group_id=1 | grep bucket=actions=set_field:172.16.150.94-\>tun_dst,set_field:82:83:ac:10:96:5e-\>eth_dst >/dev/null 2>&1
Command succeeded!
 Elapsed time for system command took: 1330 microseconds or 1 milliseconds.
gws_ip:172.16.150.94,gws_mac:82:83:ac:10:96:5e is in group rule.
Executing command: ovs-ofctl -O OpenFlow13 dump-groups br-tun | grep group_id=1 | grep bucket=actions=set_field:172.16.150.95-\>tun_dst,set_field:82:83:ac:10:96:5f-\>eth_dst >/dev/null 2>&1
Command succeeded!
 Elapsed time for system command took: 1362 microseconds or 1 milliseconds.
gws_ip:172.16.150.95,gws_mac:82:83:ac:10:96:5f is in group rule.
CHILD group rule is right
[       OK ] zeta_programming_test_cases.DISABLED_zeta_scale_container (770 ms)
[----------] 1 test from zeta_programming_test_cases (770 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (770 ms total)
[  PASSED  ] 1 test.
==========INIT TIMES:==========
g_initialize_execute_system_time = 0 microseconds or 0 milliseconds
g_initialize_execute_ovsdb_time = 0 microseconds or 0 milliseconds
g_initialize_execute_openflow_time = 0 microseconds or 0 milliseconds
==========EXECUTION TIMES:==========
g_total_execute_system_time = 766055 microseconds or 766 milliseconds
g_total_execute_ovsdb_time = 442806 microseconds or 442 milliseconds
g_total_execute_openflow_time = 19509 microseconds or 19 milliseconds
==========UPDATE GS TIMES:==========
g_total_update_GS_time = 25288 microseconds or 25 milliseconds
Program exiting, cleaning up...
ACA_OVS_L2_Programmer::execute_openflow_command ---> Entering
Executing command: ovs-ofctl del-flows br-int "udp,udp_src=68,udp_dst=67"
Command succeeded!
 Elapsed time for system command took: 1272 microseconds or 1 milliseconds.
Elapsed time for openflow client call took: 1305 microseconds or 1 milliseconds. rc: 0
ACA_OVS_L2_Programmer::execute_openflow_command <--- Exiting, rc = 0
ACA_Zeta_Programming::clear_all_data ---> Entering
ACA_Zeta_Programming::clear_all_data <--- Exiting

```