### PR TITLE
Fix for CI running the 2_ports_CREATE_test_traffic tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ before_script:
 script:
   - echo "Compile and run unit test"
   - ./test/travis_test/build_2_container.sh compile_and_run_unit_test
-  # - echo "Start ping test" # Commented out due to issue 216
-  # - ./test/travis_test/build_2_container.sh 2_port_test_traffic
+  - echo "Start ping test" # Commented out due to issue 216
+  - ./test/travis_test/build_2_container.sh 2_port_test_traffic
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM fwnetworking/ubuntu:18.04
 RUN echo "1--- installing common dependencies ---" && \
     apt-get update -y && apt-get install -y \
     rpcbind \

--- a/include/aca_zeta_programming.h
+++ b/include/aca_zeta_programming.h
@@ -80,7 +80,7 @@ class ACA_Zeta_Programming {
                     alcor::schema::GatewayConfiguration current_AuxGateway);
 
   void clear_all_data();
-  void cleanup_arp_entries();
+
   int create_zeta_config(const alcor::schema::GatewayConfiguration current_AuxGateway,
                          uint tunnel_id);
 

--- a/include/aca_zeta_programming.h
+++ b/include/aca_zeta_programming.h
@@ -80,7 +80,7 @@ class ACA_Zeta_Programming {
                     alcor::schema::GatewayConfiguration current_AuxGateway);
 
   void clear_all_data();
-
+  void cleanup_arp_entries();
   int create_zeta_config(const alcor::schema::GatewayConfiguration current_AuxGateway,
                          uint tunnel_id);
 

--- a/src/ovs/aca_arp_responder.cpp
+++ b/src/ovs/aca_arp_responder.cpp
@@ -24,132 +24,132 @@ using namespace std;
 
 namespace aca_arp_responder
 {
-ACA_ARP_Responder::ACA_ARP_Responder(){
+ACA_ARP_Responder::ACA_ARP_Responder()
+{
   _init_arp_db();
   _init_arp_ofp();
 }
 
-ACA_ARP_Responder::~ACA_ARP_Responder(){
+ACA_ARP_Responder::~ACA_ARP_Responder()
+{
   _deinit_arp_db();
-  _deinit_arp_ofp();
+  // _deinit_arp_ofp();
 }
 
-void ACA_ARP_Responder::_init_arp_db(){
+void ACA_ARP_Responder::_init_arp_db()
+{
   _arp_db.clear();
 }
 
-void ACA_ARP_Responder::_deinit_arp_db(){
+void ACA_ARP_Responder::_deinit_arp_db()
+{
   _arp_db.clear();
 }
 
-void ACA_ARP_Responder::_init_arp_ofp(){
+void ACA_ARP_Responder::_init_arp_ofp()
+{
   int overall_rc = EXIT_SUCCESS;
   unsigned long not_care_culminative_time;
 
   aca_ovs_l2_programmer::ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
-    "add-flow br-tun \"table=0,priority=50,arp,arp_op=1, actions=CONTROLLER\"",
-    not_care_culminative_time, overall_rc);
+          "add-flow br-tun \"table=0,priority=50,arp,arp_op=1, actions=CONTROLLER\"",
+          not_care_culminative_time, overall_rc);
   return;
 }
 
-void ACA_ARP_Responder::_deinit_arp_ofp(){
+void ACA_ARP_Responder::_deinit_arp_ofp()
+{
   unsigned long not_care_culminative_time;
   int overall_rc = EXIT_SUCCESS;
 
-  aca_ovs_l2_programmer::ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
-          "del-flows br-tun \"arp,arp_op=1\"",
-          not_care_culminative_time, overall_rc);
-  return;  
+  // aca_ovs_l2_programmer::ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
+  //         "del-flows br-tun \"arp,arp_op=1\"", not_care_culminative_time, overall_rc);
+  return;
 }
 
-ACA_ARP_Responder &ACA_ARP_Responder::get_instance(){
+ACA_ARP_Responder &ACA_ARP_Responder::get_instance()
+{
   static ACA_ARP_Responder instance;
   return instance;
 }
 
-
-int ACA_ARP_Responder::add_arp_entry(arp_config *arp_cfg_in){
-
+int ACA_ARP_Responder::add_arp_entry(arp_config *arp_cfg_in)
+{
   arp_entry_data stData;
   arp_table_data *current_arp_data = new arp_table_data;
 
-  try{
+  try {
     _validate_arp_entry(arp_cfg_in);
 
     ARP_ENTRY_DATA_SET((arp_entry_data *)&stData, arp_cfg_in);
     ARP_TABLE_DATA_SET(current_arp_data, arp_cfg_in);
 
-    if (_arp_db.find(stData,current_arp_data)) {
+    if (_arp_db.find(stData, current_arp_data)) {
       ACA_LOG_ERROR("Entry already existed! (ip = %s and vlan id = %u)\n",
                     arp_cfg_in->ipv4_address.c_str(), arp_cfg_in->vlan_id);
       return EXIT_FAILURE;
     }
 
-    _arp_db.insert(stData,current_arp_data);
+    _arp_db.insert(stData, current_arp_data);
 
-    ACA_LOG_DEBUG("Arp Entry with ip: %s and vlan id %u added\n",arp_cfg_in->ipv4_address.c_str(),arp_cfg_in->vlan_id);
+    ACA_LOG_DEBUG("Arp Entry with ip: %s and vlan id %u added\n",
+                  arp_cfg_in->ipv4_address.c_str(), arp_cfg_in->vlan_id);
 
     return EXIT_SUCCESS;
-  }
-  catch(std::invalid_argument &ia){
+  } catch (std::invalid_argument &ia) {
     ACA_LOG_ERROR("%s,validate arp config failed! (ip = %s and vlan id = %u)\n",
-                  ia.what(),arp_cfg_in->ipv4_address.c_str(),arp_cfg_in->vlan_id);
+                  ia.what(), arp_cfg_in->ipv4_address.c_str(), arp_cfg_in->vlan_id);
     return EXIT_FAILURE;
   }
-}  
+}
 
-int ACA_ARP_Responder::create_or_update_arp_entry(arp_config *arp_cfg_in){
+int ACA_ARP_Responder::create_or_update_arp_entry(arp_config *arp_cfg_in)
+{
   arp_entry_data stData;
   arp_table_data *current_arp_data = new arp_table_data;
 
-  try{
+  try {
     _validate_arp_entry(arp_cfg_in);
     ARP_ENTRY_DATA_SET((arp_entry_data *)&stData, arp_cfg_in);
     ARP_TABLE_DATA_SET(current_arp_data, arp_cfg_in);
 
-    if(!_arp_db.find(stData,current_arp_data)){
+    if (!_arp_db.find(stData, current_arp_data)) {
       ACA_LOG_DEBUG("Entry not exist! (ip = %s and vlan id = %u)\n",
-                    arp_cfg_in->ipv4_address.c_str(),arp_cfg_in->vlan_id);    
+                    arp_cfg_in->ipv4_address.c_str(), arp_cfg_in->vlan_id);
       add_arp_entry(arp_cfg_in);
-    }
-    else{   
+    } else {
       current_arp_data->mac_address = arp_cfg_in->mac_address;
     }
     return EXIT_SUCCESS;
-  }
-  catch(std::invalid_argument &ia){
+  } catch (std::invalid_argument &ia) {
     ACA_LOG_ERROR("%s,validate arp config failed! (ip = %s and vlan id = %u)\n",
-                  ia.what(),arp_cfg_in->ipv4_address.c_str(),arp_cfg_in->vlan_id);
+                  ia.what(), arp_cfg_in->ipv4_address.c_str(), arp_cfg_in->vlan_id);
     return EXIT_FAILURE;
   }
-
-  
-
 }
-int ACA_ARP_Responder::delete_arp_entry(arp_config *arp_cfg_in){
+int ACA_ARP_Responder::delete_arp_entry(arp_config *arp_cfg_in)
+{
   arp_entry_data stData;
   arp_table_data *current_arp_data = new arp_table_data;
 
-  try{
+  try {
     _validate_arp_entry(arp_cfg_in);
     ARP_ENTRY_DATA_SET((arp_entry_data *)&stData, arp_cfg_in);
     ARP_TABLE_DATA_SET(current_arp_data, arp_cfg_in);
 
-    if (!_arp_db.find(stData,current_arp_data)) {
+    if (!_arp_db.find(stData, current_arp_data)) {
       ACA_LOG_DEBUG("Entry not exist! (ip = %s and vlan id = %u)\n",
-                    arp_cfg_in->ipv4_address.c_str(),arp_cfg_in->vlan_id);
+                    arp_cfg_in->ipv4_address.c_str(), arp_cfg_in->vlan_id);
       return EXIT_SUCCESS;
     }
     _arp_db.erase(stData);
     return EXIT_SUCCESS;
-  }
-  catch(std::invalid_argument &ia){
+  } catch (std::invalid_argument &ia) {
     ACA_LOG_ERROR("%s,validate arp config failed! (ip = %s and vlan id = %u)\n",
-                  ia.what(),arp_cfg_in->ipv4_address.c_str(),arp_cfg_in->vlan_id);
+                  ia.what(), arp_cfg_in->ipv4_address.c_str(), arp_cfg_in->vlan_id);
     return EXIT_FAILURE;
   }
 }
-
 
 void ACA_ARP_Responder::_validate_ipv4_address(const char *ip_address)
 {
@@ -177,7 +177,7 @@ int ACA_ARP_Responder::_validate_arp_entry(arp_config *arp_cfg_in)
     throw std::invalid_argument("Input mac_string is null");
   }
 
-  if(!aca_validate_mac_address(arp_cfg_in->mac_address.c_str())){
+  if (!aca_validate_mac_address(arp_cfg_in->mac_address.c_str())) {
     throw std::invalid_argument("Virtual mac address is not in the expect format");
   }
 
@@ -192,27 +192,23 @@ int ACA_ARP_Responder::_validate_arp_entry(arp_config *arp_cfg_in)
   return EXIT_SUCCESS;
 }
 
-
-
-
 /************* Operation and procedure for dataplane *******************/
 
-
-void ACA_ARP_Responder::arp_recv(uint32_t in_port, void *vlan_hdr, void *message){
+void ACA_ARP_Responder::arp_recv(uint32_t in_port, void *vlan_hdr, void *message)
+{
   arp_message *arpmsg = nullptr;
   vlan_message *vlanmsg = nullptr;
 
-  ACA_LOG_DEBUG("Receiving arp message from inport=%u\n",in_port);
+  ACA_LOG_DEBUG("Receiving arp message from inport=%u\n", in_port);
   if (!message) {
     ACA_LOG_ERROR("%s", "ARP message is null!\n");
     return;
   }
 
-  vlanmsg = (vlan_message *)vlan_hdr; 
+  vlanmsg = (vlan_message *)vlan_hdr;
   arpmsg = (arp_message *)message;
 
-
-  if(_validate_arp_message(arpmsg)){
+  if (_validate_arp_message(arpmsg)) {
     ACA_LOG_ERROR("%s", "Invalid APR message!\n");
     return;
   }
@@ -220,9 +216,9 @@ void ACA_ARP_Responder::arp_recv(uint32_t in_port, void *vlan_hdr, void *message
   _parse_arp_request(in_port, vlanmsg, arpmsg);
 
   return;
-
 }
-void ACA_ARP_Responder::arp_xmit(uint32_t in_port, void  *vlanmsg, void *message, int is_found){
+void ACA_ARP_Responder::arp_xmit(uint32_t in_port, void *vlanmsg, void *message, int is_found)
+{
   arp_message *arpmsg = nullptr;
   string bridge = "br-tun";
   string inport = "in_port=controller";
@@ -234,29 +230,31 @@ void ACA_ARP_Responder::arp_xmit(uint32_t in_port, void  *vlanmsg, void *message
   string options;
 
   arpmsg = (arp_message *)message;
-  if(!arpmsg){
-    ACA_LOG_ERROR("%s","ARP Reply is null!\n");
+  if (!arpmsg) {
+    ACA_LOG_ERROR("%s", "ARP Reply is null!\n");
     return;
   }
 
   packet = _serialize_arp_message((vlan_message *)vlanmsg, arpmsg);
-  if(packet.empty()){
-    ACA_LOG_ERROR("%s","Serialized ARP Reply is null!\n");
+  if (packet.empty()) {
+    ACA_LOG_ERROR("%s", "Serialized ARP Reply is null!\n");
     return;
   }
-  if(is_found){
-    options = inport + whitespace + packetpre + packet +whitespace + action;
-  }
-  else{
-    options = inport + whitespace + packetpre + packet +whitespace + rs_action;
+  if (is_found) {
+    options = inport + whitespace + packetpre + packet + whitespace + action;
+  } else {
+    options = inport + whitespace + packetpre + packet + whitespace + rs_action;
   }
 
-  aca_ovs_control::ACA_OVS_Control::get_instance().packet_out(bridge.c_str(),options.c_str());
+  aca_ovs_control::ACA_OVS_Control::get_instance().packet_out(bridge.c_str(),
+                                                              options.c_str());
 
   delete arpmsg;
 }
 
-void ACA_ARP_Responder::_parse_arp_request(uint32_t in_port, vlan_message *vlanmsg, arp_message *arpmsg){
+void ACA_ARP_Responder::_parse_arp_request(uint32_t in_port, vlan_message *vlanmsg,
+                                           arp_message *arpmsg)
+{
   arp_entry_data stData;
   arp_table_data *current_arp_data = new arp_table_data;
   arp_message *arpreply = nullptr;
@@ -265,30 +263,30 @@ void ACA_ARP_Responder::_parse_arp_request(uint32_t in_port, vlan_message *vlanm
   stData.ipv4_address = _get_requested_ip(arpmsg);
 
   // get the vlan id from vlan header
-  if(vlanmsg){
-    stData.vlan_id = ntohs(vlanmsg->vlan_tci) & 0x0fff; 
-  }
-  else{
+  if (vlanmsg) {
+    stData.vlan_id = ntohs(vlanmsg->vlan_tci) & 0x0fff;
+  } else {
     stData.vlan_id = 0;
   }
-  
+
   // if not find the corresponding mac address in the db based on ip and vlan id, resubmit to table 22
   // else construct an arp reply
-  if(!_arp_db.find(stData,current_arp_data)){
+  if (!_arp_db.find(stData, current_arp_data)) {
     ACA_LOG_DEBUG("ARP entry does not exist! (ip = %s and vlan id = %u)\n",
-                  stData.ipv4_address.c_str(),stData.vlan_id);
+                  stData.ipv4_address.c_str(), stData.vlan_id);
     arp_xmit(in_port, vlanmsg, arpmsg, 0);
     return;
-  }
-  else{
+  } else {
     ACA_LOG_DEBUG("ARP entry exist (ip = %s and vlan id = %u) with mac = %s\n",
-                  stData.ipv4_address.c_str(),stData.vlan_id,current_arp_data->mac_address.c_str());
-    arpreply = _pack_arp_reply(arpmsg,current_arp_data->mac_address);
+                  stData.ipv4_address.c_str(), stData.vlan_id,
+                  current_arp_data->mac_address.c_str());
+    arpreply = _pack_arp_reply(arpmsg, current_arp_data->mac_address);
     arp_xmit(in_port, vlanmsg, arpreply, 1);
   }
 }
 
-arp_message *ACA_ARP_Responder::_pack_arp_reply(arp_message *arpreq, string mac_address){
+arp_message *ACA_ARP_Responder::_pack_arp_reply(arp_message *arpreq, string mac_address)
+{
   arp_message *arpreply = nullptr;
   arpreply = new arp_message();
   unsigned int tmp_mac[6];
@@ -299,26 +297,26 @@ arp_message *ACA_ARP_Responder::_pack_arp_reply(arp_message *arpreq, string mac_
   arpreply->hln = arpreq->hln;
   arpreply->pln = arpreq->pln;
   arpreply->op = htons(2);
-  memcpy(arpreply->tha,arpreq->sha,6);
+  memcpy(arpreply->tha, arpreq->sha, 6);
   arpreply->spa = arpreq->tpa;
-  sscanf(mac_address.c_str(),"%02x:%02x:%02x:%02x:%02x:%02x",
-        tmp_mac,tmp_mac+1,tmp_mac+2,tmp_mac+3,tmp_mac+4,tmp_mac+5);
-  for(int i = 0; i < 6; i++){
+  sscanf(mac_address.c_str(), "%02x:%02x:%02x:%02x:%02x:%02x", tmp_mac,
+         tmp_mac + 1, tmp_mac + 2, tmp_mac + 3, tmp_mac + 4, tmp_mac + 5);
+  for (int i = 0; i < 6; i++) {
     arpreply->sha[i] = tmp_mac[i];
   }
   arpreply->tpa = arpreq->spa;
-  
+
   return arpreply;
 }
 
-
-int ACA_ARP_Responder::_validate_arp_message(arp_message *arpmsg){
-  if(!arpmsg){
+int ACA_ARP_Responder::_validate_arp_message(arp_message *arpmsg)
+{
+  if (!arpmsg) {
     ACA_LOG_ERROR("%s", "ARP message is null!\n");
     return EXIT_FAILURE;
   }
 
-  if(ntohs(arpmsg->op) != 1){
+  if (ntohs(arpmsg->op) != 1) {
     ACA_LOG_ERROR("%s", "ARP message is not a ARP request!\n");
     return EXIT_FAILURE;
   }
@@ -326,10 +324,11 @@ int ACA_ARP_Responder::_validate_arp_message(arp_message *arpmsg){
   return EXIT_SUCCESS;
 }
 
-string ACA_ARP_Responder::_get_requested_ip(arp_message *arpmsg){
+string ACA_ARP_Responder::_get_requested_ip(arp_message *arpmsg)
+{
   string requested_ip;
   struct in_addr inaddr;
-  if(!arpmsg){
+  if (!arpmsg) {
     ACA_LOG_ERROR("%s", "ARP message is null!\n");
     return string();
   }
@@ -340,23 +339,24 @@ string ACA_ARP_Responder::_get_requested_ip(arp_message *arpmsg){
   return requested_ip;
 }
 
-string ACA_ARP_Responder::_serialize_arp_message(vlan_message *vlanmsg, arp_message *arpmsg){
+string ACA_ARP_Responder::_serialize_arp_message(vlan_message *vlanmsg, arp_message *arpmsg)
+{
   string packet;
   char str[80];
-  if(!arpmsg){
+  if (!arpmsg) {
     return string();
   }
 
   //fix arp header
-  sprintf(str,"%04x",ntohs(arpmsg->hrd));
+  sprintf(str, "%04x", ntohs(arpmsg->hrd));
   packet.append(str);
-  sprintf(str,"%04x",ntohs(arpmsg->pro));
+  sprintf(str, "%04x", ntohs(arpmsg->pro));
   packet.append(str);
-  sprintf(str,"%02x",arpmsg->hln);
+  sprintf(str, "%02x", arpmsg->hln);
   packet.append(str);
-  sprintf(str,"%02x",arpmsg->pln);
+  sprintf(str, "%02x", arpmsg->pln);
   packet.append(str);
-  sprintf(str,"%04x",ntohs(arpmsg->op));
+  sprintf(str, "%04x", ntohs(arpmsg->op));
   packet.append(str);
 
   //fix ip and mac address of source node
@@ -364,7 +364,7 @@ string ACA_ARP_Responder::_serialize_arp_message(vlan_message *vlanmsg, arp_mess
     sprintf(str, "%02x", arpmsg->sha[i]);
     packet.append(str);
   }
-  sprintf(str,"%08x",ntohl(arpmsg->spa));
+  sprintf(str, "%08x", ntohl(arpmsg->spa));
   packet.append(str);
 
   //fix ip and mac address of target node
@@ -372,7 +372,7 @@ string ACA_ARP_Responder::_serialize_arp_message(vlan_message *vlanmsg, arp_mess
     sprintf(str, "%02x", arpmsg->tha[i]);
     packet.append(str);
   }
-  sprintf(str,"%08x",ntohl(arpmsg->tpa));
+  sprintf(str, "%08x", ntohl(arpmsg->tpa));
   packet.append(str);
 
   //fix the ethernet header
@@ -382,22 +382,21 @@ string ACA_ARP_Responder::_serialize_arp_message(vlan_message *vlanmsg, arp_mess
     packet_header.append(str);
   }
 
-  for (int i = 0; i < 6; i++){
+  for (int i = 0; i < 6; i++) {
     sprintf(str, "%02x", arpmsg->sha[i]);
     packet_header.append(str);
   }
   //fix the vlan header
-  if(vlanmsg){
-    sprintf(str,"%04x",ntohs(vlanmsg->vlan_proto));
+  if (vlanmsg) {
+    sprintf(str, "%04x", ntohs(vlanmsg->vlan_proto));
     packet_header.append(str);
-    sprintf(str,"%04x",ntohs(vlanmsg->vlan_tci));
+    sprintf(str, "%04x", ntohs(vlanmsg->vlan_tci));
     packet_header.append(str);
   }
 
   //arp protocol：0806
   packet_header.append("0806");
-  packet.insert(0,packet_header);
+  packet.insert(0, packet_header);
   return packet;
 }
 } // namespace aca_arp_responder
-

--- a/src/ovs/aca_arp_responder.cpp
+++ b/src/ovs/aca_arp_responder.cpp
@@ -59,8 +59,8 @@ void ACA_ARP_Responder::_init_arp_ofp()
 
 void ACA_ARP_Responder::_deinit_arp_ofp()
 {
-  unsigned long not_care_culminative_time;
-  int overall_rc = EXIT_SUCCESS;
+  // unsigned long not_care_culminative_time;
+  // int overall_rc = EXIT_SUCCESS;
 
   // aca_ovs_l2_programmer::ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
   //         "del-flows br-tun \"arp,arp_op=1\"", not_care_culminative_time, overall_rc);

--- a/src/ovs/aca_arp_responder.cpp
+++ b/src/ovs/aca_arp_responder.cpp
@@ -33,7 +33,7 @@ ACA_ARP_Responder::ACA_ARP_Responder()
 ACA_ARP_Responder::~ACA_ARP_Responder()
 {
   _deinit_arp_db();
-  // _deinit_arp_ofp();
+  _deinit_arp_ofp();
 }
 
 void ACA_ARP_Responder::_init_arp_db()
@@ -59,11 +59,11 @@ void ACA_ARP_Responder::_init_arp_ofp()
 
 void ACA_ARP_Responder::_deinit_arp_ofp()
 {
-  // unsigned long not_care_culminative_time;
-  // int overall_rc = EXIT_SUCCESS;
+  unsigned long not_care_culminative_time;
+  int overall_rc = EXIT_SUCCESS;
 
-  // aca_ovs_l2_programmer::ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
-  //         "del-flows br-tun \"arp,arp_op=1\"", not_care_culminative_time, overall_rc);
+  aca_ovs_l2_programmer::ACA_OVS_L2_Programmer::get_instance().execute_openflow_command(
+          "del-flows br-tun \"arp,arp_op=1\"", not_care_culminative_time, overall_rc);
   return;
 }
 

--- a/src/zeta/aca_zeta_programming.cpp
+++ b/src/zeta/aca_zeta_programming.cpp
@@ -26,7 +26,6 @@ using namespace aca_ovs_control;
 using namespace aca_vlan_manager;
 using namespace aca_ovs_l2_programmer;
 
-vector<string> remove_arp_commands;
 namespace aca_zeta_programming
 {
 ACA_Zeta_Programming::ACA_Zeta_Programming()
@@ -298,16 +297,6 @@ int ACA_Zeta_Programming::delete_zeta_config(const alcor::schema::GatewayConfigu
   return overall_rc;
 }
 
-void ACA_Zeta_Programming::cleanup_arp_entries()
-{
-  ACA_LOG_INFO("%s", "Start cleaning all the arp entries...");
-  for (string cmd : remove_arp_commands) {
-    ACA_LOG_INFO("Removing this arp entry: %s\n", "cmd");
-    aca_net_config::Aca_Net_Config::get_instance().execute_system_command(cmd);
-  }
-  ACA_LOG_INFO("%s", "Finished cleaning all the arp entries...");
-}
-
 int ACA_Zeta_Programming::_create_zeta_group_entry(zeta_config *zeta_cfg)
 {
   ACA_LOG_DEBUG("%s", "ACA_Zeta_Programming::_create_zeta_group_entry ---> Entering\n");
@@ -330,8 +319,7 @@ int ACA_Zeta_Programming::_create_zeta_group_entry(zeta_config *zeta_cfg)
         // add the static arp entries
         string static_arp_string = "arp -s " + hash_node->getKey().ip_addr +
                                    " " + hash_node->getKey().mac_addr;
-        string static_arp_remove_cmd = "arp -d " + hash_node->getKey().ip_addr;
-        remove_arp_commands.push_back(static_arp_remove_cmd);
+
         aca_net_config::Aca_Net_Config::get_instance().execute_system_command(static_arp_string);
 
         // fill zeta_gws
@@ -386,8 +374,7 @@ int ACA_Zeta_Programming::_update_zeta_group_entry(zeta_config *zeta_cfg)
         // add the static arp entries
         string static_arp_string = "arp -s " + hash_node->getKey().ip_addr +
                                    " " + hash_node->getKey().mac_addr;
-        string static_arp_remove_cmd = "arp -d " + hash_node->getKey().ip_addr;
-        remove_arp_commands.push_back(static_arp_remove_cmd);
+
         aca_net_config::Aca_Net_Config::get_instance().execute_system_command(static_arp_string);
 
         cmd += ",bucket=\"set_field:" + hash_node->getKey().ip_addr +

--- a/src/zeta/aca_zeta_programming.cpp
+++ b/src/zeta/aca_zeta_programming.cpp
@@ -26,8 +26,7 @@ using namespace aca_ovs_control;
 using namespace aca_vlan_manager;
 using namespace aca_ovs_l2_programmer;
 
-
-
+vector<string> remove_arp_commands;
 namespace aca_zeta_programming
 {
 ACA_Zeta_Programming::ACA_Zeta_Programming()
@@ -299,6 +298,16 @@ int ACA_Zeta_Programming::delete_zeta_config(const alcor::schema::GatewayConfigu
   return overall_rc;
 }
 
+void ACA_Zeta_Programming::cleanup_arp_entries()
+{
+  ACA_LOG_INFO("%s", "Start cleaning all the arp entries...");
+  for (string cmd : remove_arp_commands) {
+    ACA_LOG_INFO("Removing this arp entry: %s\n", "cmd");
+    aca_net_config::Aca_Net_Config::get_instance().execute_system_command(cmd);
+  }
+  ACA_LOG_INFO("%s", "Finished cleaning all the arp entries...");
+}
+
 int ACA_Zeta_Programming::_create_zeta_group_entry(zeta_config *zeta_cfg)
 {
   ACA_LOG_DEBUG("%s", "ACA_Zeta_Programming::_create_zeta_group_entry ---> Entering\n");
@@ -321,6 +330,8 @@ int ACA_Zeta_Programming::_create_zeta_group_entry(zeta_config *zeta_cfg)
         // add the static arp entries
         string static_arp_string = "arp -s " + hash_node->getKey().ip_addr +
                                    " " + hash_node->getKey().mac_addr;
+        string static_arp_remove_cmd = "arp -d " + hash_node->getKey().ip_addr;
+        remove_arp_commands.push_back(static_arp_remove_cmd);
         aca_net_config::Aca_Net_Config::get_instance().execute_system_command(static_arp_string);
 
         // fill zeta_gws
@@ -375,6 +386,8 @@ int ACA_Zeta_Programming::_update_zeta_group_entry(zeta_config *zeta_cfg)
         // add the static arp entries
         string static_arp_string = "arp -s " + hash_node->getKey().ip_addr +
                                    " " + hash_node->getKey().mac_addr;
+        string static_arp_remove_cmd = "arp -d " + hash_node->getKey().ip_addr;
+        remove_arp_commands.push_back(static_arp_remove_cmd);
         aca_net_config::Aca_Net_Config::get_instance().execute_system_command(static_arp_string);
 
         cmd += ",bucket=\"set_field:" + hash_node->getKey().ip_addr +
@@ -478,7 +491,8 @@ bool ACA_Zeta_Programming::group_rule_info_correct(uint group_id, string gws_ip,
   string opt1 = "group_id=" + to_string(group_id);
   const string tail = "-\\>tun_dst";
   const string tail_mac = "-\\>eth_dst";
-  string opt2 = "bucket=actions=set_field:" + gws_ip + tail +",set_field:" + gws_mac + tail_mac + " >/dev/null 2>&1";
+  string opt2 = "bucket=actions=set_field:" + gws_ip + tail +
+                ",set_field:" + gws_mac + tail_mac + " >/dev/null 2>&1";
   string cmd_string = dump_flows + " | grep " + opt1 + " | grep " + opt2;
   overall_rc = aca_net_config::Aca_Net_Config::get_instance().execute_system_command(cmd_string);
   if (overall_rc == EXIT_SUCCESS) {

--- a/test/gtest/aca_test_ovs_l2.cpp
+++ b/test/gtest/aca_test_ovs_l2.cpp
@@ -518,6 +518,32 @@ TEST(ovs_l2_test_cases, 1_port_CREATE_plus_10_l2_neighbor_CREATE)
 
 TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)
 {
+  string two_port_vmac_address_1 = "fa:16:3e:d7:f2:6a";
+  string two_port_vmac_address_2 = "fa:16:3e:d7:f2:6b";
+  string two_port_vmac_address_3 = "fa:16:3e:d7:f2:6c";
+  string two_port_vmac_address_4 = "fa:16:3e:d7:f2:6d";
+
+  string two_port_vip_address_1 = "11.0.0.105";
+  string two_port_vip_address_2 = "11.0.1.106";
+  string two_port_vip_address_3 = "11.0.0.107";
+  string two_port_vip_address_4 = "11.0.1.108";
+
+  string two_port_vpc_id_1 = "2b08a5bc-b718-11ea-b3de-111111111112";
+  string two_port_vpc_id_2 = "2b08a5bc-b718-11ea-b3de-222222222223";
+
+  string two_port_port_id_1 = "11111111-b718-11ea-b3de-111111111112";
+  string two_port_port_id_2 = "12222222-b718-11ea-b3de-111111111113";
+  string two_port_port_id_3 = "13333333-b718-11ea-b3de-111111111114";
+  string two_port_port_id_4 = "14444444-b718-11ea-b3de-111111111115";
+
+  string two_port_port_name_1 = aca_get_port_name(two_port_port_id_1);
+  string two_port_port_name_2 = aca_get_port_name(two_port_port_id_2);
+  string two_port_port_name_3 = aca_get_port_name(two_port_port_id_3);
+  string two_port_port_name_4 = aca_get_port_name(two_port_port_id_4);
+
+  string two_port_subnet_id_1 = "27330ae4-b718-11ea-b3df-111111111113";
+  string two_port_subnet_id_2 = "27330ae4-b718-11ea-b3df-222222222224";
+
   ulong not_care_culminative_time = 0;
   string cmd_string;
   int overall_rc;
@@ -537,10 +563,10 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)
   overall_rc = EXIT_SUCCESS;
 
   // monitor br-tun for arp request message
-  ovs_monitor_thread = 
-    new thread(bind(&ACA_OVS_Control::monitor, &ACA_OVS_Control::get_instance(), "br-tun", "resume"));
+  ovs_monitor_thread =
+          new thread(bind(&ACA_OVS_Control::monitor,
+                          &ACA_OVS_Control::get_instance(), "br-tun", "resume"));
   ovs_monitor_thread->detach();
-
 
   GoalState GoalState_builder;
   PortState *new_port_states = GoalState_builder.add_port_states();
@@ -550,33 +576,33 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)
 
   // fill in port state structs for port 1
   PortConfiguration *PortConfiguration_builder = new_port_states->mutable_configuration();
-  PortConfiguration_builder->set_revision_number(1);
+  PortConfiguration_builder->set_revision_number(2);
   PortConfiguration_builder->set_update_type(UpdateType::FULL);
-  PortConfiguration_builder->set_id(port_id_1);
+  PortConfiguration_builder->set_id(two_port_port_id_1);
 
-  PortConfiguration_builder->set_vpc_id(vpc_id_1);
-  PortConfiguration_builder->set_name(port_name_1);
-  PortConfiguration_builder->set_mac_address(vmac_address_1);
+  PortConfiguration_builder->set_vpc_id(two_port_vpc_id_1);
+  PortConfiguration_builder->set_name(two_port_port_name_1);
+  PortConfiguration_builder->set_mac_address(two_port_vmac_address_1);
   PortConfiguration_builder->set_admin_state_up(true);
 
   PortConfiguration_FixedIp *FixedIp_builder = PortConfiguration_builder->add_fixed_ips();
-  FixedIp_builder->set_subnet_id(subnet_id_1);
-  FixedIp_builder->set_ip_address(vip_address_1);
+  FixedIp_builder->set_subnet_id(two_port_subnet_id_1);
+  FixedIp_builder->set_ip_address(two_port_vip_address_1);
 
   PortConfiguration_SecurityGroupId *SecurityGroup_builder =
           PortConfiguration_builder->add_security_group_ids();
-  SecurityGroup_builder->set_id("1");
+  SecurityGroup_builder->set_id("2");
 
   // fill in subnet state structs
   new_subnet_states->set_operation_type(OperationType::INFO);
 
   SubnetConfiguration *SubnetConiguration_builder =
           new_subnet_states->mutable_configuration();
-  SubnetConiguration_builder->set_revision_number(1);
-  SubnetConiguration_builder->set_vpc_id(vpc_id_1);
-  SubnetConiguration_builder->set_id(subnet_id_1);
-  SubnetConiguration_builder->set_cidr("10.0.0.0/24");
-  SubnetConiguration_builder->set_tunnel_id(20);
+  SubnetConiguration_builder->set_revision_number(2);
+  SubnetConiguration_builder->set_vpc_id(two_port_vpc_id_1);
+  SubnetConiguration_builder->set_id(two_port_subnet_id_1);
+  SubnetConiguration_builder->set_cidr("11.0.0.0/24");
+  SubnetConiguration_builder->set_tunnel_id(21);
 
   // add a new neighbor state with CREATE
   NeighborState *new_neighbor_states = GoalState_builder.add_neighbor_states();
@@ -585,18 +611,18 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)
   // fill in neighbor state structs for port 3
   NeighborConfiguration *NeighborConfiguration_builder =
           new_neighbor_states->mutable_configuration();
-  NeighborConfiguration_builder->set_revision_number(1);
+  NeighborConfiguration_builder->set_revision_number(2);
 
-  NeighborConfiguration_builder->set_vpc_id(vpc_id_1);
-  NeighborConfiguration_builder->set_id(port_id_3);
-  NeighborConfiguration_builder->set_mac_address(vmac_address_3);
+  NeighborConfiguration_builder->set_vpc_id(two_port_vpc_id_1);
+  NeighborConfiguration_builder->set_id(two_port_port_id_3);
+  NeighborConfiguration_builder->set_mac_address(two_port_vmac_address_3);
   NeighborConfiguration_builder->set_host_ip_address(remote_ip_2);
 
   NeighborConfiguration_FixedIp *FixedIp_builder2 =
           NeighborConfiguration_builder->add_fixed_ips();
   FixedIp_builder2->set_neighbor_type(NeighborType::L2);
-  FixedIp_builder2->set_subnet_id(subnet_id_1);
-  FixedIp_builder2->set_ip_address(vip_address_3);
+  FixedIp_builder2->set_subnet_id(two_port_subnet_id_1);
+  FixedIp_builder2->set_ip_address(two_port_vip_address_3);
 
   // set demo mode
   bool previous_demo_mode = g_demo_mode;
@@ -612,30 +638,31 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)
 
   // check to ensure the port 1 is created and setup correctly
   ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "get Interface " + port_name_1 + " ofport", not_care_culminative_time, overall_rc);
+          "get Interface " + two_port_port_name_1 + " ofport",
+          not_care_culminative_time, overall_rc);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
   // setup the configuration for port 2
-  PortConfiguration_builder->set_id(port_id_2);
-  PortConfiguration_builder->set_vpc_id(vpc_id_2);
-  PortConfiguration_builder->set_name(port_name_2);
-  PortConfiguration_builder->set_mac_address(vmac_address_2);
-  FixedIp_builder->set_ip_address(vip_address_2);
-  FixedIp_builder->set_subnet_id(subnet_id_2);
+  PortConfiguration_builder->set_id(two_port_port_id_2);
+  PortConfiguration_builder->set_vpc_id(two_port_vpc_id_2);
+  PortConfiguration_builder->set_name(two_port_port_name_2);
+  PortConfiguration_builder->set_mac_address(two_port_vmac_address_2);
+  FixedIp_builder->set_ip_address(two_port_vip_address_2);
+  FixedIp_builder->set_subnet_id(two_port_subnet_id_2);
 
   // fill in subnet state structs
-  SubnetConiguration_builder->set_vpc_id(vpc_id_2);
-  SubnetConiguration_builder->set_id(subnet_id_2);
-  SubnetConiguration_builder->set_cidr("10.0.1.0/24");
-  SubnetConiguration_builder->set_tunnel_id(30);
+  SubnetConiguration_builder->set_vpc_id(two_port_vpc_id_2);
+  SubnetConiguration_builder->set_id(two_port_subnet_id_2);
+  SubnetConiguration_builder->set_cidr("11.0.1.0/24");
+  SubnetConiguration_builder->set_tunnel_id(31);
 
   // fill in neighbor state structs for port 4
-  NeighborConfiguration_builder->set_vpc_id(vpc_id_2);
-  NeighborConfiguration_builder->set_id(port_id_4);
-  NeighborConfiguration_builder->set_mac_address(vmac_address_4);
-  FixedIp_builder2->set_subnet_id(subnet_id_2);
-  FixedIp_builder2->set_ip_address(vip_address_4);
+  NeighborConfiguration_builder->set_vpc_id(two_port_vpc_id_2);
+  NeighborConfiguration_builder->set_id(two_port_port_id_4);
+  NeighborConfiguration_builder->set_mac_address(two_port_vmac_address_4);
+  FixedIp_builder2->set_subnet_id(two_port_subnet_id_2);
+  FixedIp_builder2->set_ip_address(two_port_vip_address_4);
 
   // create a new port 2 + port 4 neighbor in demo mode
   overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
@@ -648,39 +675,44 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)
 
   // check to ensure the port 2 is created and setup correctly
   ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "get Interface " + port_name_2 + " ofport", not_care_culminative_time, overall_rc);
+          "get Interface " + two_port_port_name_2 + " ofport",
+          not_care_culminative_time, overall_rc);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
+  ACA_LOG_INFO("-------- After setting up, printout ifconfig: %d -------------\n", overall_rc);
+
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command("ifconfig");
+
   // test traffic between the two newly created ports
-  cmd_string = "ping -I " + vip_address_1 + " -c1 " + vip_address_2;
+  cmd_string = "ping -I " + two_port_vip_address_1 + " -c1 " + two_port_vip_address_2;
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
-  cmd_string = "ping -I " + vip_address_2 + " -c1 " + vip_address_1;
+  cmd_string = "ping -I " + two_port_vip_address_2 + " -c1 " + two_port_vip_address_1;
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
   // test valid traffic from parent to child
-  cmd_string = "ping -I " + vip_address_1 + " -c1 " + vip_address_3;
+  cmd_string = "ping -I " + two_port_vip_address_1 + " -c1 " + two_port_vip_address_3;
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
-  cmd_string = "ping -I " + vip_address_2 + " -c1 " + vip_address_4;
+  cmd_string = "ping -I " + two_port_vip_address_2 + " -c1 " + two_port_vip_address_4;
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
   // test invalid traffic from parent to child with different subnets
-  cmd_string = "ping -I " + vip_address_1 + " -c1 " + vip_address_4;
+  cmd_string = "ping -I " + two_port_vip_address_1 + " -c1 " + two_port_vip_address_4;
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
   EXPECT_NE(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
-  cmd_string = "ping -I " + vip_address_2 + " -c1 " + vip_address_3;
+  cmd_string = "ping -I " + two_port_vip_address_2 + " -c1 " + two_port_vip_address_3;
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
   EXPECT_NE(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
@@ -694,16 +726,23 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)
   overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
           GoalState_builder, gsOperationalReply);
   ASSERT_EQ(overall_rc, EXIT_SUCCESS);
+  ACA_LOG_INFO("-------- Delete port 4 was succcessful: %d -------------\n", overall_rc);
+
+  ACA_LOG_INFO("-------- After deleting port 4, printout ifconfig: %d -------------\n",
+               overall_rc);
+
+  overall_rc = Aca_Net_Config::get_instance().execute_system_command("ifconfig");
+
   overall_rc = EXIT_SUCCESS;
 
   // should not be able to ping port 4 anymore
-  cmd_string = "ping -I " + vip_address_2 + " -c1 " + vip_address_4;
+  cmd_string = "ping -I " + two_port_vip_address_2 + " -c1 " + two_port_vip_address_4;
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
   EXPECT_NE(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
   // but still have to ping port 3 since it is not deleted
-  cmd_string = "ping -I " + vip_address_1 + " -c1 " + vip_address_3;
+  cmd_string = "ping -I " + two_port_vip_address_1 + " -c1 " + two_port_vip_address_3;
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
@@ -728,6 +767,32 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)
 
 TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_CHILD)
 {
+  string two_port_vmac_address_1 = "fa:16:3e:d7:f2:6a";
+  string two_port_vmac_address_2 = "fa:16:3e:d7:f2:6b";
+  string two_port_vmac_address_3 = "fa:16:3e:d7:f2:6c";
+  string two_port_vmac_address_4 = "fa:16:3e:d7:f2:6d";
+
+  string two_port_vip_address_1 = "11.0.0.105";
+  string two_port_vip_address_2 = "11.0.1.106";
+  string two_port_vip_address_3 = "11.0.0.107";
+  string two_port_vip_address_4 = "11.0.1.108";
+
+  string two_port_vpc_id_1 = "2b08a5bc-b718-11ea-b3de-111111111112";
+  string two_port_vpc_id_2 = "2b08a5bc-b718-11ea-b3de-222222222223";
+
+  string two_port_port_id_1 = "11111111-b718-11ea-b3de-111111111112";
+  string two_port_port_id_2 = "12222222-b718-11ea-b3de-111111111113";
+  string two_port_port_id_3 = "13333333-b718-11ea-b3de-111111111114";
+  string two_port_port_id_4 = "14444444-b718-11ea-b3de-111111111115";
+
+  string two_port_port_name_1 = aca_get_port_name(two_port_port_id_1);
+  string two_port_port_name_2 = aca_get_port_name(two_port_port_id_2);
+  string two_port_port_name_3 = aca_get_port_name(two_port_port_id_3);
+  string two_port_port_name_4 = aca_get_port_name(two_port_port_id_4);
+
+  string two_port_subnet_id_1 = "27330ae4-b718-11ea-b3df-111111111113";
+  string two_port_subnet_id_2 = "27330ae4-b718-11ea-b3df-222222222224";
+
   ulong not_care_culminative_time = 0;
   string cmd_string;
   int overall_rc;
@@ -747,8 +812,9 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_CHILD)
   overall_rc = EXIT_SUCCESS;
 
   // monitor br-tun for arp request message
-  ovs_monitor_thread = 
-    new thread(bind(&ACA_OVS_Control::monitor, &ACA_OVS_Control::get_instance(), "br-tun", "resume"));
+  ovs_monitor_thread =
+          new thread(bind(&ACA_OVS_Control::monitor,
+                          &ACA_OVS_Control::get_instance(), "br-tun", "resume"));
 
   GoalState GoalState_builder;
   PortState *new_port_states = GoalState_builder.add_port_states();
@@ -758,33 +824,33 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_CHILD)
 
   // fill in port state structs for port 3
   PortConfiguration *PortConfiguration_builder = new_port_states->mutable_configuration();
-  PortConfiguration_builder->set_revision_number(1);
+  PortConfiguration_builder->set_revision_number(2);
   PortConfiguration_builder->set_update_type(UpdateType::FULL);
-  PortConfiguration_builder->set_id(port_id_3);
+  PortConfiguration_builder->set_id(two_port_port_id_3);
 
-  PortConfiguration_builder->set_vpc_id(vpc_id_1);
-  PortConfiguration_builder->set_name(port_name_3);
-  PortConfiguration_builder->set_mac_address(vmac_address_3);
+  PortConfiguration_builder->set_vpc_id(two_port_vpc_id_1);
+  PortConfiguration_builder->set_name(two_port_port_name_3);
+  PortConfiguration_builder->set_mac_address(two_port_vmac_address_3);
   PortConfiguration_builder->set_admin_state_up(true);
 
   PortConfiguration_FixedIp *FixedIp_builder = PortConfiguration_builder->add_fixed_ips();
-  FixedIp_builder->set_subnet_id(subnet_id_1);
-  FixedIp_builder->set_ip_address(vip_address_3);
+  FixedIp_builder->set_subnet_id(two_port_subnet_id_1);
+  FixedIp_builder->set_ip_address(two_port_vip_address_3);
 
   PortConfiguration_SecurityGroupId *SecurityGroup_builder =
           PortConfiguration_builder->add_security_group_ids();
-  SecurityGroup_builder->set_id("1");
+  SecurityGroup_builder->set_id("2");
 
   // fill in subnet state structs
   new_subnet_states->set_operation_type(OperationType::INFO);
 
   SubnetConfiguration *SubnetConiguration_builder =
           new_subnet_states->mutable_configuration();
-  SubnetConiguration_builder->set_revision_number(1);
-  SubnetConiguration_builder->set_vpc_id(vpc_id_1);
-  SubnetConiguration_builder->set_id(subnet_id_1);
-  SubnetConiguration_builder->set_cidr("10.0.0.0/24");
-  SubnetConiguration_builder->set_tunnel_id(20);
+  SubnetConiguration_builder->set_revision_number(2);
+  SubnetConiguration_builder->set_vpc_id(two_port_vpc_id_1);
+  SubnetConiguration_builder->set_id(two_port_subnet_id_1);
+  SubnetConiguration_builder->set_cidr("11.0.0.0/24");
+  SubnetConiguration_builder->set_tunnel_id(21);
 
   // add a new neighbor state with CREATE
   NeighborState *new_neighbor_states = GoalState_builder.add_neighbor_states();
@@ -793,18 +859,18 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_CHILD)
   // fill in neighbor state structs for port 1
   NeighborConfiguration *NeighborConfiguration_builder =
           new_neighbor_states->mutable_configuration();
-  NeighborConfiguration_builder->set_revision_number(1);
+  NeighborConfiguration_builder->set_revision_number(2);
 
-  NeighborConfiguration_builder->set_vpc_id(vpc_id_1);
-  NeighborConfiguration_builder->set_id(port_id_1);
-  NeighborConfiguration_builder->set_mac_address(vmac_address_1);
+  NeighborConfiguration_builder->set_vpc_id(two_port_vpc_id_1);
+  NeighborConfiguration_builder->set_id(two_port_port_id_1);
+  NeighborConfiguration_builder->set_mac_address(two_port_vmac_address_1);
   NeighborConfiguration_builder->set_host_ip_address(remote_ip_1);
 
   NeighborConfiguration_FixedIp *FixedIp_builder2 =
           NeighborConfiguration_builder->add_fixed_ips();
   FixedIp_builder2->set_neighbor_type(NeighborType::L2);
-  FixedIp_builder2->set_subnet_id(subnet_id_1);
-  FixedIp_builder2->set_ip_address(vip_address_1);
+  FixedIp_builder2->set_subnet_id(two_port_subnet_id_1);
+  FixedIp_builder2->set_ip_address(two_port_vip_address_1);
 
   // set demo mode
   bool previous_demo_mode = g_demo_mode;
@@ -820,30 +886,31 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_CHILD)
 
   // check to ensure the port 3 is created and setup correctly
   ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "get Interface " + port_name_3 + " ofport", not_care_culminative_time, overall_rc);
+          "get Interface " + two_port_port_name_3 + " ofport",
+          not_care_culminative_time, overall_rc);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
   // setup the configuration for port 4
-  PortConfiguration_builder->set_id(port_id_4);
-  PortConfiguration_builder->set_vpc_id(vpc_id_2);
-  PortConfiguration_builder->set_name(port_name_4);
-  PortConfiguration_builder->set_mac_address(vmac_address_4);
-  FixedIp_builder->set_ip_address(vip_address_4);
-  FixedIp_builder->set_subnet_id(subnet_id_2);
+  PortConfiguration_builder->set_id(two_port_port_id_4);
+  PortConfiguration_builder->set_vpc_id(two_port_vpc_id_2);
+  PortConfiguration_builder->set_name(two_port_port_name_4);
+  PortConfiguration_builder->set_mac_address(two_port_vmac_address_4);
+  FixedIp_builder->set_ip_address(two_port_vip_address_4);
+  FixedIp_builder->set_subnet_id(two_port_subnet_id_2);
 
   // fill in subnet state structs
-  SubnetConiguration_builder->set_vpc_id(vpc_id_2);
-  SubnetConiguration_builder->set_id(subnet_id_2);
-  SubnetConiguration_builder->set_cidr("10.0.1.0/24");
-  SubnetConiguration_builder->set_tunnel_id(30);
+  SubnetConiguration_builder->set_vpc_id(two_port_vpc_id_2);
+  SubnetConiguration_builder->set_id(two_port_subnet_id_2);
+  SubnetConiguration_builder->set_cidr("11.0.1.0/24");
+  SubnetConiguration_builder->set_tunnel_id(31);
 
   // fill in port state structs for NEIGHBOR_CREATE_UPDATE for port 2
-  NeighborConfiguration_builder->set_vpc_id(vpc_id_2);
-  NeighborConfiguration_builder->set_id(port_id_2);
-  NeighborConfiguration_builder->set_mac_address(vmac_address_2);
-  FixedIp_builder2->set_subnet_id(subnet_id_2);
-  FixedIp_builder2->set_ip_address(vip_address_2);
+  NeighborConfiguration_builder->set_vpc_id(two_port_vpc_id_2);
+  NeighborConfiguration_builder->set_id(two_port_port_id_2);
+  NeighborConfiguration_builder->set_mac_address(two_port_vmac_address_2);
+  FixedIp_builder2->set_subnet_id(two_port_subnet_id_2);
+  FixedIp_builder2->set_ip_address(two_port_vip_address_2);
 
   // create a new port 4 + port 2 neighbor in demo mode
   overall_rc = Aca_Comm_Manager::get_instance().update_goal_state(
@@ -856,17 +923,18 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_CHILD)
 
   // check to ensure the port 4 is created and setup correctly
   ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "get Interface " + port_name_4 + " ofport", not_care_culminative_time, overall_rc);
+          "get Interface " + two_port_port_name_4 + " ofport",
+          not_care_culminative_time, overall_rc);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
   // test traffic between the two newly created ports
-  cmd_string = "ping -I " + vip_address_3 + " -c1 " + vip_address_4;
+  cmd_string = "ping -I " + two_port_vip_address_3 + " -c1 " + two_port_vip_address_4;
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;
 
-  cmd_string = "ping -I " + vip_address_4 + " -c1 " + vip_address_3;
+  cmd_string = "ping -I " + two_port_vip_address_4 + " -c1 " + two_port_vip_address_3;
   overall_rc = Aca_Net_Config::get_instance().execute_system_command(cmd_string);
   EXPECT_EQ(overall_rc, EXIT_SUCCESS);
   overall_rc = EXIT_SUCCESS;

--- a/test/gtest/aca_test_ovs_l2.cpp
+++ b/test/gtest/aca_test_ovs_l2.cpp
@@ -752,17 +752,6 @@ TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_PARENT)
   // free the allocated configurations since we are done with it now
   new_neighbor_states->clear_configuration();
   new_subnet_states->clear_configuration();
-
-  // delete br-int and br-tun bridges
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-int", not_care_culminative_time, overall_rc);
-  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
-
-  ACA_OVS_L2_Programmer::get_instance().execute_ovsdb_command(
-          "del-br br-tun", not_care_culminative_time, overall_rc);
-  EXPECT_EQ(overall_rc, EXIT_SUCCESS);
-  overall_rc = EXIT_SUCCESS;
 }
 
 TEST(ovs_l2_test_cases, DISABLED_2_ports_CREATE_test_traffic_CHILD)

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -476,6 +476,8 @@ TEST(zeta_programming_test_cases, create_auxgateway_test)
   retcode = Aca_Comm_Manager::get_instance().update_goal_state(
           GoalState_builder, gsOperationalReply);
 
+  ACA_Zeta_Programming::get_instance().cleanup_arp_entries();
+
   EXPECT_EQ(retcode, EXIT_SUCCESS);
 }
 

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -410,7 +410,7 @@ TEST(zeta_programming_test_cases, delete_zeta_config_valid)
   EXPECT_EQ(retcode, EXIT_SUCCESS);
 }
 
-TEST(zeta_programming_test_cases, create_auxgateway_test)
+TEST(zeta_programming_test_cases, DISABLED_create_auxgateway_test)
 {
   ulong not_care_culminative_time = 0;
   int overall_rc;
@@ -475,8 +475,6 @@ TEST(zeta_programming_test_cases, create_auxgateway_test)
 
   retcode = Aca_Comm_Manager::get_instance().update_goal_state(
           GoalState_builder, gsOperationalReply);
-
-  ACA_Zeta_Programming::get_instance().cleanup_arp_entries();
 
   EXPECT_EQ(retcode, EXIT_SUCCESS);
 }

--- a/test/travis_test/build_2_container.sh
+++ b/test/travis_test/build_2_container.sh
@@ -19,14 +19,16 @@ if [ "$1" == "compile_and_run_unit_test" ]; then
   docker images
   echo "    --- container list ---"
   docker ps -a
-  echo "    --- create container ---"
+  echo "    --- create network ---"
+  docker network create --subnet=172.18.0.0/16 mynet123
+  echo "    --- create container with IP addresses assigned ---"
   docker rm -f aca_PARENT || true
-  docker create -v $code_dir:/mnt/host/code -it --privileged --cap-add=NET_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --name aca_PARENT aca_build0:latest /bin/bash
+  docker create -v $code_dir:/mnt/host/code -it --privileged --ip 172.18.0.2 --cap-add=NET_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --name aca_PARENT aca_build0:latest /bin/bash
   docker start aca_PARENT
   docker exec aca_PARENT bash -c "/etc/init.d/openvswitch-switch restart && \
   ovs-vswitchd --pidfile --detach"
   docker rm -f aca_CHILD || true
-  docker create -v $code_dir:/mnt/host/code -it --privileged --cap-add=NET_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --name aca_CHILD aca_build0:latest /bin/bash
+  docker create -v $code_dir:/mnt/host/code -it --privileged  --ip 172.18.0.3 --cap-add=NET_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --name aca_CHILD aca_build0:latest /bin/bash
   docker start aca_CHILD
   docker exec aca_CHILD bash -c "/etc/init.d/openvswitch-switch restart && \
   ovs-vswitchd --pidfile --detach"
@@ -43,7 +45,7 @@ if [ "$1" == "compile_and_run_unit_test" ]; then
 elif [ "$1" == "2_port_test_traffic" ]; then
   echo "    --- 2_ports_CREATE test case---"
   # run DISABLED_2_ports_CREATE_test_traffic_PARENT and DISABLED_2_ports_CREATE_test_traffic_CHILD
-  docker exec aca_CHILD bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_CHILD" &
+  docker exec aca_CHILD bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_CHILD -p 172.18.0.2" &
   sleep 5
-  docker exec aca_PARENT bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_PARENT"
+  docker exec aca_PARENT bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_PARENT -c 172.18.0.3"
 fi

--- a/test/travis_test/build_2_container.sh
+++ b/test/travis_test/build_2_container.sh
@@ -46,8 +46,6 @@ elif [ "$1" == "2_port_test_traffic" ]; then
   child_container_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' aca_CHILD)
   echo "aca_PARENT ip: $parent_container_ip"
   echo "aca_CHILD ip: $child_container_ip"
-  docker exec aca_CHILD -c "/etc/init.d/openvswitch-switch restart && ovs-vswitchd --pidfile --detach" || true
-  docker exec aca_PARENT -c "/etc/init.d/openvswitch-switch restart && ovs-vswitchd --pidfile --detach" || true
   # run DISABLED_2_ports_CREATE_test_traffic_PARENT and DISABLED_2_ports_CREATE_test_traffic_CHILD
   docker exec -d aca_CHILD /bin/bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_CHILD -p $parent_container_ip" &
   sleep 5

--- a/test/travis_test/build_2_container.sh
+++ b/test/travis_test/build_2_container.sh
@@ -19,7 +19,7 @@ if [ "$1" == "compile_and_run_unit_test" ]; then
   docker images
   echo "    --- container list ---"
   docker ps -a
-  echo "    --- create container with IP addresses assigned ---"
+  echo "    --- create container ---"
   docker rm -f aca_PARENT || true
   docker create -v $code_dir:/mnt/host/code -it --privileged --cap-add=NET_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --name aca_PARENT aca_build0:latest /bin/bash
   docker start aca_PARENT

--- a/test/travis_test/build_2_container.sh
+++ b/test/travis_test/build_2_container.sh
@@ -21,6 +21,7 @@ if [ "$1" == "compile_and_run_unit_test" ]; then
   docker ps -a
   echo "    --- create network ---"
   docker network create --subnet=172.18.0.0/16 mynet123
+  
   echo "    --- create container with IP addresses assigned ---"
   docker rm -f aca_PARENT || true
   docker create -v $code_dir:/mnt/host/code -it --privileged --ip 172.18.0.2 --cap-add=NET_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --name aca_PARENT aca_build0:latest /bin/bash

--- a/test/travis_test/build_2_container.sh
+++ b/test/travis_test/build_2_container.sh
@@ -49,7 +49,7 @@ elif [ "$1" == "2_port_test_traffic" ]; then
   docker exec aca_CHILD -c "/etc/init.d/openvswitch-switch restart && ovs-vswitchd --pidfile --detach" || true
   docker exec aca_PARENT -c "/etc/init.d/openvswitch-switch restart && ovs-vswitchd --pidfile --detach" || true
   # run DISABLED_2_ports_CREATE_test_traffic_PARENT and DISABLED_2_ports_CREATE_test_traffic_CHILD
-  docker exec aca_CHILD bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_CHILD -p $parent_container_ip" &
+  docker exec -d aca_CHILD /bin/bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_CHILD -p $parent_container_ip" &
   sleep 5
-  docker exec aca_PARENT bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_PARENT -c $child_container_ip"
+  docker exec aca_PARENT /bin/bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_PARENT -c $child_container_ip"
 fi

--- a/test/travis_test/build_2_container.sh
+++ b/test/travis_test/build_2_container.sh
@@ -19,16 +19,14 @@ if [ "$1" == "compile_and_run_unit_test" ]; then
   docker images
   echo "    --- container list ---"
   docker ps -a
-  echo "    --- create network ---"
-  docker network create --subnet=172.18.0.0/16 mynet123
   echo "    --- create container with IP addresses assigned ---"
   docker rm -f aca_PARENT || true
-  docker create -v $code_dir:/mnt/host/code -it --privileged --ip 172.18.0.2 --cap-add=NET_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --name aca_PARENT aca_build0:latest /bin/bash
+  docker create -v $code_dir:/mnt/host/code -it --privileged --cap-add=NET_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --name aca_PARENT aca_build0:latest /bin/bash
   docker start aca_PARENT
   docker exec aca_PARENT bash -c "/etc/init.d/openvswitch-switch restart && \
   ovs-vswitchd --pidfile --detach"
   docker rm -f aca_CHILD || true
-  docker create -v $code_dir:/mnt/host/code -it --privileged  --ip 172.18.0.3 --cap-add=NET_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --name aca_CHILD aca_build0:latest /bin/bash
+  docker create -v $code_dir:/mnt/host/code -it --privileged --cap-add=NET_ADMIN --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --name aca_CHILD aca_build0:latest /bin/bash
   docker start aca_CHILD
   docker exec aca_CHILD bash -c "/etc/init.d/openvswitch-switch restart && \
   ovs-vswitchd --pidfile --detach"
@@ -44,8 +42,14 @@ if [ "$1" == "compile_and_run_unit_test" ]; then
 
 elif [ "$1" == "2_port_test_traffic" ]; then
   echo "    --- 2_ports_CREATE test case---"
+  parent_container_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' aca_PARENT)
+  child_container_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' aca_CHILD)
+  echo "aca_PARENT ip: $parent_container_ip"
+  echo "aca_CHILD ip: $child_container_ip"
+  docker exec aca_CHILD -c "/etc/init.d/openvswitch-switch restart && ovs-vswitchd --pidfile --detach" || true
+  docker exec aca_PARENT -c "/etc/init.d/openvswitch-switch restart && ovs-vswitchd --pidfile --detach" || true
   # run DISABLED_2_ports_CREATE_test_traffic_PARENT and DISABLED_2_ports_CREATE_test_traffic_CHILD
-  docker exec aca_CHILD bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_CHILD -p 172.18.0.2" &
+  docker exec aca_CHILD bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_CHILD -p $parent_container_ip" &
   sleep 5
-  docker exec aca_PARENT bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_PARENT -c 172.18.0.3"
+  docker exec aca_PARENT bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_PARENT -c $child_container_ip"
 fi


### PR DESCRIPTION
This PR attemps to do the following:

1. Enable the CI to run the 2_ports_CREATE_test_traffic tests, with docker network created, fixed IPs assigned to the two containers, and the 2_ports_CREATE_test_traffic tests called with the above IPs.