### PR TITLE
Temporary fix for port update/create

### DIFF
--- a/src/dp_abstraction/aca_dataplane_ovs.cpp
+++ b/src/dp_abstraction/aca_dataplane_ovs.cpp
@@ -216,7 +216,7 @@ int ACA_Dataplane_OVS::update_port_state_workitem(const PortState current_PortSt
     }
     alcor::schema::OperationType current_operation_type =
             current_PortState.operation_type();
-    if (current_PortState.operation_type() == UPDATE) {
+    if (current_PortState.operation_type() == OperationType::UPDATE) {
       if (!current_PortConfiguration.device_id().empty() &&
           !current_PortConfiguration.device_owner().empty()) {
         current_operation_type = OperationType::CREATE;

--- a/src/dp_abstraction/aca_dataplane_ovs.cpp
+++ b/src/dp_abstraction/aca_dataplane_ovs.cpp
@@ -269,7 +269,7 @@ int ACA_Dataplane_OVS::update_port_state_workitem(const PortState current_PortSt
       // only delete scenario is supported now
       // VM was created with port specified, then delete the VM
       // ACA will receive update with no device_id and device_owner
-      ACA_LOG_INFO("%s", "Port update is not yet supported.\n");
+      ACA_LOG_INFO("%s", "Port update is not yet supported. \n");
       break;
       // [[fallthrough]];
     case OperationType::DELETE:


### PR DESCRIPTION
This PR proposes temporary fix for the following scenarios:
* Nova sends port update operation with nonempty device_id and device_owner (of value compute:nova). This request should be treated as CREATE from Alcor perspective.
* Nova sends port update operation with empty device_id and device_owner. This request should be treated as DELETE.

The ultimate fix should be in Port Manager as the resource owner. We proposes this fix as a short-term solution to verify E2E success.  