### PR TITLE
Grpc unit test

### DIFF
--- a/include/aca_grpc.h
+++ b/include/aca_grpc.h
@@ -45,6 +45,8 @@ class GoalStateProvisionerImpl final : public GoalStateProvisioner::Service {
 
   void RunServer();
 
+  void ConnectToNCM();
+
   private:
   std::unique_ptr<Server> server;
 };

--- a/include/aca_grpc.h
+++ b/include/aca_grpc.h
@@ -32,7 +32,6 @@ class GoalStateProvisionerImpl final : public GoalStateProvisioner::Service {
   std::unique_ptr<GoalStateProvisioner::Stub> stub_;
   std::shared_ptr<grpc_impl::Channel> chan_;
   HostRequestReply RequestGoalStates(HostRequest *request);
-  
   // ~GoalStateProvisionerImpl();
   explicit GoalStateProvisionerImpl(){};
   Status PushNetworkResourceStates(ServerContext *context, const GoalState *goalState,

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -47,7 +47,9 @@ HostRequestReply GoalStateProvisionerImpl::RequestGoalStates(HostRequest *reques
   if (current_state == grpc_connectivity_state::GRPC_CHANNEL_SHUTDOWN ||
       current_state == grpc_connectivity_state::GRPC_CHANNEL_TRANSIENT_FAILURE) {
     ACA_LOG_INFO("%s, it is: [%d]\n",
-                 "Channel state is not READY/CONNECTING/IDLE", current_state);
+                 "Channel state is not READY/CONNECTING/IDLE. Try to reconnnect.",
+                 current_state);
+    this->ConnectToNCM();
     reply.mutable_operation_statuses()->Add();
     reply.mutable_operation_statuses()->at(0).set_operation_status(OperationStatus::FAILURE);
     return reply;
@@ -113,7 +115,7 @@ Status GoalStateProvisionerImpl::ShutDownServer()
   return Status::OK;
 }
 
-void GoalStateProvisionerImpl::RunServer()
+void GoalStateProvisionerImpl::ConnectToNCM()
 {
   ACA_LOG_INFO("%s\n", "Trying to init a new sub to connect to the NCM");
   grpc::ChannelArguments args;
@@ -130,7 +132,11 @@ void GoalStateProvisionerImpl::RunServer()
   stub_ = GoalStateProvisioner::NewStub(chan_);
 
   ACA_LOG_INFO("%s\n", "After initing a new sub to connect to the NCM");
+}
 
+void GoalStateProvisionerImpl::RunServer()
+{
+  this->ConnectToNCM();
   ServerBuilder builder;
   string GRPC_SERVER_ADDRESS = "0.0.0.0:" + g_grpc_server_port;
   builder.AddListeningPort(GRPC_SERVER_ADDRESS, grpc::InsecureServerCredentials());

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(
     gtest/aca_test_oam.cpp
     gtest/aca_test_zeta_programming.cpp
     gtest/aca_test_arp.cpp
+    gtest/aca_test_on_demand.cpp
 )
 
 # Link test executable against gtest & gtest_main

--- a/test/func_tests/gs_tests.cpp
+++ b/test/func_tests/gs_tests.cpp
@@ -142,11 +142,18 @@ class GoalStateProvisionerServer final : public GoalStateProvisioner::Service {
   grpc::Status RequestGoalStates(ServerContext *ctx, const HostRequest *request,
                                  HostRequestReply *response) override
   {
+    string expected_request_id = "12345";
     ctx->client_metadata();
     request->CheckInitialized();
     ACA_LOG_INFO("%s", "Test Server code called!");
     response->mutable_operation_statuses()->Add();
-    response->mutable_operation_statuses()->at(0).set_operation_status(OperationStatus::SUCCESS);
+    response->mutable_operation_statuses(0)->set_request_id(
+            request->state_requests(0).request_id());
+    if (request->state_requests(0).request_id() == expected_request_id) {
+      response->mutable_operation_statuses()->at(0).set_operation_status(OperationStatus::SUCCESS);
+    } else {
+      response->mutable_operation_statuses()->at(0).set_operation_status(OperationStatus::FAILURE);
+    }
     return grpc::Status::OK;
   }
 };

--- a/test/func_tests/gs_tests.cpp
+++ b/test/func_tests/gs_tests.cpp
@@ -139,20 +139,22 @@ void print_goalstateReply(GoalStateOperationReply gsOperationReply)
 
 // Synchronous server implementation to test the grpc client's connectivity.
 class GoalStateProvisionerServer final : public GoalStateProvisioner::Service {
-  void replyGoalStateRequest(ServerContext *ctx, const GoalState *goalState,
-                             GoalStateOperationReply *goalStateOperationReply)
+  grpc::Status RequestGoalStates(ServerContext *ctx, const HostRequest *request,
+                                 HostRequestReply *response) override
   {
     ctx->client_metadata();
-    goalState->CheckInitialized();
+    request->CheckInitialized();
     ACA_LOG_INFO("%s", "Test Server code called!");
-    goalStateOperationReply->mutable_operation_statuses()->Add();
-    goalStateOperationReply->mutable_operation_statuses()->at(0).set_operation_status(
-            OperationStatus::SUCCESS);
+    response->mutable_operation_statuses()->Add();
+    response->mutable_operation_statuses()->at(0).set_operation_status(OperationStatus::SUCCESS);
+    return grpc::Status::OK;
   }
 };
 
 int RunServer()
 {
+  ACA_LOG_INFO("%s", "GS test runnig as a grpc server\n");
+
   std::string server_address("0.0.0.0:54321");
 
   GoalStateProvisionerServer service;
@@ -160,8 +162,10 @@ int RunServer()
   ServerBuilder builder;
   // Listen on the given address without any authentication mechanism.
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  ACA_LOG_INFO("%s", "Added listening port\n");
 
   builder.RegisterService(&service);
+  ACA_LOG_INFO("%s", "Registered service\n");
 
   std::unique_ptr<Server> server(builder.BuildAndStart());
 

--- a/test/func_tests/gs_tests.cpp
+++ b/test/func_tests/gs_tests.cpp
@@ -50,7 +50,10 @@ string g_ofctl_options = EMPTY_STRING;
 string g_ncm_address = EMPTY_STRING;
 string g_ncm_port = EMPTY_STRING;
 string g_grpc_server_port = EMPTY_STRING;
+// by default, this should run as GRCP client, unless specified by the corresponding flag.
+bool g_run_as_server = false;
 GoalStateProvisionerImpl *g_grpc_server = NULL;
+// GoalStateProvisionerServer *g_test_grcp_server = NULL;
 
 // total time for execute_system_command in microseconds
 std::atomic_ulong g_total_execute_system_time(0);
@@ -132,6 +135,42 @@ void print_goalstateReply(GoalStateOperationReply gsOperationReply)
                 us_to_ms(gsOperationReply.message_total_operation_time()));
 
   g_total_ACA_Message_time += gsOperationReply.message_total_operation_time();
+}
+
+// Synchronous server implementation to test the grpc client's connectivity.
+class GoalStateProvisionerServer final : public GoalStateProvisioner::Service {
+  void replyGoalStateRequest(ServerContext *ctx, const GoalState *goalState,
+                             GoalStateOperationReply *goalStateOperationReply)
+  {
+    ctx->client_metadata();
+    goalState->CheckInitialized();
+    ACA_LOG_INFO("%s", "Test Server code called!");
+    goalStateOperationReply->mutable_operation_statuses()->Add();
+    goalStateOperationReply->mutable_operation_statuses()->at(0).set_operation_status(
+            OperationStatus::SUCCESS);
+  }
+};
+
+int RunServer()
+{
+    std::string server_address("0.0.0.0:54321");
+
+  GoalStateProvisionerServer service;
+
+  ServerBuilder builder;
+  // Listen on the given address without any authentication mechanism.
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+
+  builder.RegisterService(&service);
+
+  std::unique_ptr<Server> server(builder.BuildAndStart());
+
+  ACA_LOG_INFO("Test Server listening on %s", server_address.c_str());
+  // Wait for the server to shutdown.
+  // Note that some other thread must be responsible for shutting down the server for this call to ever return.
+  server->Wait();
+  // server->Shutdown();
+  return 0;
 }
 
 class GoalStateProvisionerClient {
@@ -534,51 +573,9 @@ void parse_goalstate(GoalState parsed_struct, GoalState GoalState_builder)
   fprintf(stdout, "All content matched!\n");
 }
 
-int main(int argc, char *argv[])
+int run_as_client()
 {
-  int option;
   int rc;
-  ACA_LOG_INIT(ACALOGNAME);
-
-  // Register the signal handlers
-  signal(SIGINT, aca_signal_handler);
-  signal(SIGTERM, aca_signal_handler);
-
-  while ((option = getopt(argc, argv, "s:p:d")) != -1) {
-    switch (option) {
-    case 's':
-      g_grpc_server_ip = optarg;
-      break;
-    case 'p':
-      g_grpc_port = optarg;
-      break;
-    case 'd':
-      g_debug_mode = true;
-      break;
-    default: /* the '?' case when the option is not recognized */
-      fprintf(stderr,
-              "Usage: %s\n"
-              "\t\t[-s grpc server]\n"
-              "\t\t[-p grpc port]\n"
-              "\t\t[-d enable debug mode]\n",
-              argv[0]);
-      exit(EXIT_FAILURE);
-    }
-  }
-
-  // fill in the grpc server and protocol if it is not provided in
-  // command line arg
-  if (g_grpc_server_ip == EMPTY_STRING) {
-    g_grpc_server_ip = LOCALHOST;
-  }
-  if (g_grpc_port == EMPTY_STRING) {
-    g_grpc_port = GRPC_PORT;
-  }
-
-  // Verify that the version of the library that we linked against is
-  // compatible with the version of the headers we compiled against.
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
   string port_name_postfix = "11111111-2222-3333-4444-555555555555";
   string ip_address_prefix = "10.0.0.";
   string remote_ip_address_prefix = "123.0.0.";
@@ -710,8 +707,71 @@ int main(int argc, char *argv[])
 
     grpc_client.send_goalstate_stream(10, "32");
   }
+  return rc;
+}
+
+int main(int argc, char *argv[])
+{
+  int option;
+  int rc;
+  ACA_LOG_INIT(ACALOGNAME);
+
+  // Register the signal handlers
+  signal(SIGINT, aca_signal_handler);
+  signal(SIGTERM, aca_signal_handler);
+
+  while ((option = getopt(argc, argv, "s:p:dm")) != -1) {
+    switch (option) {
+    case 's':
+      g_grpc_server_ip = optarg;
+      break;
+    case 'p':
+      g_grpc_port = optarg;
+      break;
+    case 'd':
+      g_debug_mode = true;
+      break;
+    case 'm':
+      g_run_as_server = true;
+      break;
+    default: /* the '?' case when the option is not recognized */
+      fprintf(stderr,
+              "Usage: %s\n"
+              "\t\t[-s grpc server]\n"
+              "\t\t[-p grpc port]\n"
+              "\t\t[-d enable debug mode]\n"
+              "\t\t[-m If this flag is passed in, gs test runs as grpc server, which listens on localhost:54321; otherwise it runs as a grpc client]\n",
+              argv[0]);
+      exit(EXIT_FAILURE);
+    }
+  }
+
+  // fill in the grpc server and protocol if it is not provided in
+  // command line arg
+  if (g_grpc_server_ip == EMPTY_STRING) {
+    g_grpc_server_ip = LOCALHOST;
+  }
+  if (g_grpc_port == EMPTY_STRING) {
+    g_grpc_port = GRPC_PORT;
+  }
+
+  if (g_run_as_server) {
+    rc = RunServer();
+  } else {
+    rc = run_as_client();
+  }
+  // Verify that the version of the library that we linked against is
+  // compatible with the version of the headers we compiled against.
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   aca_cleanup();
 
   return rc;
 }
+
+// int run_as_server()
+// {
+//   int rc;
+
+//   return rc;
+// }

--- a/test/func_tests/gs_tests.cpp
+++ b/test/func_tests/gs_tests.cpp
@@ -153,7 +153,7 @@ class GoalStateProvisionerServer final : public GoalStateProvisioner::Service {
 
 int RunServer()
 {
-    std::string server_address("0.0.0.0:54321");
+  std::string server_address("0.0.0.0:54321");
 
   GoalStateProvisionerServer service;
 
@@ -768,10 +768,3 @@ int main(int argc, char *argv[])
 
   return rc;
 }
-
-// int run_as_server()
-// {
-//   int rc;
-
-//   return rc;
-// }

--- a/test/gtest/aca_test_main.cpp
+++ b/test/gtest/aca_test_main.cpp
@@ -144,9 +144,15 @@ int main(int argc, char **argv)
 
   testing::InitGoogleTest(&argc, argv);
 
-  while ((option = getopt(argc, argv, "p:c:n:")) != -1) {
+  while ((option = getopt(argc, argv, "a:p:m:c:n:")) != -1) {
     switch (option) {
+    case 'a':
+      g_ncm_address = optarg;
+      break;
     case 'p':
+      g_ncm_port = optarg;
+      break;
+    case 'm':
       remote_ip_1 = optarg;
       break;
     case 'c':
@@ -158,6 +164,8 @@ int main(int argc, char **argv)
     default: /* the '?' case when the option is not recognized */
       fprintf(stderr,
               "Usage: %s\n"
+              "\t\t[-a NCM IP Address]\n"
+              "\t\t[-p NCM Port]\n"
               "\t\t[-m parent machine IP]\n"
               "\t\t[-c child machine IP]\n"
               "\t\t[-n neighbors to create (default: 10)]\n",
@@ -167,9 +175,10 @@ int main(int argc, char **argv)
   }
 
   g_grpc_server = new GoalStateProvisionerImpl();
-  g_grpc_server_thread = new std::thread(std::bind(&GoalStateProvisionerImpl::RunServer, g_grpc_server));
+  g_grpc_server_thread =
+          new std::thread(std::bind(&GoalStateProvisionerImpl::RunServer, g_grpc_server));
   g_grpc_server_thread->detach();
-  
+
   int rc = RUN_ALL_TESTS();
 
   aca_cleanup();

--- a/test/gtest/aca_test_on_demand.cpp
+++ b/test/gtest/aca_test_on_demand.cpp
@@ -22,10 +22,38 @@ TEST(aca_on_demand_testcases, DISABLED_grpc_client_connectivity_test)
   ACA_LOG_INFO("%s", "Start of DISABLED_grpc_client_connectivity_test\n");
   ASSERT_NE(g_grpc_server, nullptr);
   ACA_LOG_INFO("%s", "Made sure that g_grpc_server is not null\n");
-  HostRequest example_request;
-  example_request.add_state_requests();
+
+  // test sending a request with an expected request_id, which should return
+  // a reply with the same request_id, and a SUCCESS operation status.
+
+  HostRequest example_request_with_expected_id;
+  example_request_with_expected_id.add_state_requests();
+  string expected_request_id = "12345";
+  string unexpected_request_id = "54321";
+
+  example_request_with_expected_id.mutable_state_requests(0)->set_request_id(expected_request_id);
   ACA_LOG_INFO("Channel state: %d\n", g_grpc_server->chan_->GetState(false));
-  alcor::schema::HostRequestReply reply = g_grpc_server->RequestGoalStates(&example_request);
-  ACA_LOG_INFO("Reply operation status size: %d\n", reply.operation_statuses_size());
-  ASSERT_EQ(reply.operation_statuses(0).operation_status(), OperationStatus::SUCCESS);
+  ACA_LOG_INFO("Request one's request ID: %s\n",
+               example_request_with_expected_id.state_requests(0).request_id().c_str());
+  alcor::schema::HostRequestReply reply_one =
+          g_grpc_server->RequestGoalStates(&example_request_with_expected_id);
+  ACA_LOG_INFO("Reply one's operation status size: %d\n",
+               reply_one.operation_statuses_size());
+  ASSERT_EQ(reply_one.operation_statuses(0).operation_status(), OperationStatus::SUCCESS);
+  ASSERT_EQ(reply_one.operation_statuses(0).request_id(), expected_request_id);
+
+  // test sending a request with an expected request_id, which should return
+  // a reply with the same request_id, and a SUCCESS operation status.
+
+  HostRequest example_request_with_unexpected_id;
+  example_request_with_unexpected_id.add_state_requests();
+  example_request_with_unexpected_id.mutable_state_requests(0)->set_request_id(unexpected_request_id);
+  ACA_LOG_INFO("Request two's request ID: %s\n",
+               example_request_with_unexpected_id.state_requests(0).request_id().c_str());
+  alcor::schema::HostRequestReply reply_two =
+          g_grpc_server->RequestGoalStates(&example_request_with_unexpected_id);
+  ACA_LOG_INFO("Reply two's operation status size: %d\n",
+               reply_two.operation_statuses_size());
+  ASSERT_EQ(reply_two.operation_statuses(0).operation_status(), OperationStatus::FAILURE);
+  ASSERT_EQ(reply_two.operation_statuses(0).request_id(), unexpected_request_id);
 }

--- a/test/gtest/aca_test_on_demand.cpp
+++ b/test/gtest/aca_test_on_demand.cpp
@@ -26,5 +26,6 @@ TEST(aca_on_demand_testcases, DISABLED_grpc_client_connectivity_test)
   example_request.add_state_requests();
   ACA_LOG_INFO("Channel state: %d\n", g_grpc_server->chan_->GetState(false));
   alcor::schema::HostRequestReply reply = g_grpc_server->RequestGoalStates(&example_request);
+  ACA_LOG_INFO("Reply operation status size: %d\n", reply.operation_statuses_size());
   ASSERT_EQ(reply.operation_statuses(0).operation_status(), OperationStatus::SUCCESS);
 }

--- a/test/gtest/aca_test_on_demand.cpp
+++ b/test/gtest/aca_test_on_demand.cpp
@@ -1,0 +1,27 @@
+#include "aca_log.h"
+#include "aca_util.h"
+#include "aca_config.h"
+#include "aca_vlan_manager.h"
+#include "aca_ovs_l2_programmer.h"
+#include "aca_comm_mgr.h"
+#include "gtest/gtest.h"
+#include "goalstate.pb.h"
+#include "aca_ovs_control.h"
+#include <unistd.h> /* for getopt */
+#include <iostream>
+#include <string>
+#include <thread>
+#include "aca_grpc.h"
+#include "aca_on_demand_engine.h"
+
+extern GoalStateProvisionerImpl *g_grpc_server;
+
+TEST(aca_on_demand_testcases, DISABLED_grpc_client_connectivity_test)
+{
+  ACA_LOG_INFO("%s", "Start of DISABLED_grpc_client_connectivity_test");
+  ASSERT_NE(g_grpc_server, NULL);
+  ACA_LOG_INFO("%s", "Made sure that g_grpc_server is not null");
+  HostRequest *example_request;
+  alcor::schema::HostRequestReply reply = g_grpc_server->RequestGoalStates(example_request);
+  ASSERT_EQ(reply.operation_statuses(0), OperationStatus::SUCCESS);
+}

--- a/test/gtest/aca_test_on_demand.cpp
+++ b/test/gtest/aca_test_on_demand.cpp
@@ -18,10 +18,13 @@ extern GoalStateProvisionerImpl *g_grpc_server;
 
 TEST(aca_on_demand_testcases, DISABLED_grpc_client_connectivity_test)
 {
-  ACA_LOG_INFO("%s", "Start of DISABLED_grpc_client_connectivity_test");
-  ASSERT_NE(g_grpc_server, NULL);
-  ACA_LOG_INFO("%s", "Made sure that g_grpc_server is not null");
-  HostRequest *example_request;
-  alcor::schema::HostRequestReply reply = g_grpc_server->RequestGoalStates(example_request);
-  ASSERT_EQ(reply.operation_statuses(0), OperationStatus::SUCCESS);
+  sleep(10);
+  ACA_LOG_INFO("%s", "Start of DISABLED_grpc_client_connectivity_test\n");
+  ASSERT_NE(g_grpc_server, nullptr);
+  ACA_LOG_INFO("%s", "Made sure that g_grpc_server is not null\n");
+  HostRequest example_request;
+  example_request.add_state_requests();
+  ACA_LOG_INFO("Channel state: %d\n", g_grpc_server->chan_->GetState(false));
+  alcor::schema::HostRequestReply reply = g_grpc_server->RequestGoalStates(&example_request);
+  ASSERT_EQ(reply.operation_statuses(0).operation_status(), OperationStatus::SUCCESS);
 }

--- a/test/travis_test/build_2_container.sh
+++ b/test/travis_test/build_2_container.sh
@@ -39,7 +39,7 @@ if [ "$1" == "compile_and_run_unit_test" ]; then
   echo "    --- basic test case---"
   # run basic test case, ./build/tests/aca_tests
   docker exec aca_CHILD bash -c "cd /mnt/host/code && ./build/tests/aca_tests"
-
+  
 elif [ "$1" == "2_port_test_traffic" ]; then
   echo "    --- 2_ports_CREATE test case---"
   parent_container_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' aca_PARENT)
@@ -50,4 +50,11 @@ elif [ "$1" == "2_port_test_traffic" ]; then
   docker exec -d aca_CHILD /bin/bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_CHILD_V2 -p $parent_container_ip" &
   sleep 5
   docker exec aca_PARENT /bin/bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_2_ports_CREATE_test_traffic_PARENT_V2 -c $child_container_ip"
+
+  # run fake grpc server
+  docker exec aca_PARENT bash -c "cd /mnt/host/code && nohup ./build/tests/gs_tests -m -d &"
+  # run testcase to try to connect to the fake server
+  docker exec aca_CHILD bash -c "cd /mnt/host/code && ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_grpc_client_connectivity_test -a $parent_container_ip  -p 54321"
+
+
 fi


### PR DESCRIPTION
This PR does the following:

1. Added functionality and option for `gs_tests` to run as a grpc client/server.
2. Added `DISABLED_grpc_client_connectivity_test` disable testcase, which tests the basic grpc channel connectivity.
3. Improved grpc client channel's connectivity check by changing the condition to check.

How to run the new testcase:
1. On machine one, run `sudo ./build/tests/gs_tests -m -d` to start the grpc server, which pretends to be the NCM.
2. On machine two, run `sudo ./build/tests/aca_tests --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_grpc_client_connectivity_test -a machine_one_ip -p 54321` to trigger the testcase.