### PR TITLE
Update subnet routing correctly.

### DIFF
--- a/src/dhcp/aca_dhcp_server.cpp
+++ b/src/dhcp/aca_dhcp_server.cpp
@@ -587,10 +587,10 @@ int ACA_Dhcp_Server::_pack_dhcp_opt_dns(uint8_t *option, string dns_addresses[])
   uint32_t *dns_address_options = (uint32_t *)dr->dns;
   for (int i = 0; i < DHCP_MSG_OPTS_DNS_LENGTH; i++) {
     if (dns_addresses[i] == "") {
-      dr->len = i * 4; 
+      dr->len = i * 4;
       break;
     }
-    
+
     dns_address_options[i] = ip4tol(dns_addresses[i]);
   }
   return dr->len;
@@ -611,7 +611,7 @@ void ACA_Dhcp_Server::_init_dhcp_msg_ops()
   _parse_dhcp_msg_ops[DHCP_MSG_DHCPINFORM] = &aca_dhcp_server::ACA_Dhcp_Server::_parse_dhcp_none;
 }
 
-void ACA_Dhcp_Server::_parse_dhcp_none(uint32_t /* in_port */ , dhcp_message *dhcpmsg)
+void ACA_Dhcp_Server::_parse_dhcp_none(uint32_t /* in_port */, dhcp_message *dhcpmsg)
 {
   ACA_LOG_ERROR("Wrong DHCP message type! (Message type = %d)\n",
                 _get_message_type(dhcpmsg));
@@ -670,7 +670,7 @@ ACA_Dhcp_Server::_pack_dhcp_offer(dhcp_message *dhcpdiscover, dhcp_entry_data *p
   opts_len += DHCP_OPT_CLV_HEADER + DHCP_OPT_LEN_4BYTE;
 
   //DHCP Options: server identifier
-  _pack_dhcp_opt_server_id(&pos[opts_len], DHCP_MSG_SERVER_ID); 
+  _pack_dhcp_opt_server_id(&pos[opts_len], DHCP_MSG_SERVER_ID);
   opts_len += DHCP_OPT_CLV_HEADER + DHCP_OPT_LEN_4BYTE;
 
   //DHCP Options: subnet mask
@@ -762,7 +762,7 @@ dhcp_message *ACA_Dhcp_Server::_pack_dhcp_ack(dhcp_message *dhcpreq, dhcp_entry_
   opts_len += DHCP_OPT_CLV_HEADER + DHCP_OPT_LEN_4BYTE;
 
   //DHCP Options: server identifier
-  _pack_dhcp_opt_server_id(&pos[opts_len], DHCP_MSG_SERVER_ID); 
+  _pack_dhcp_opt_server_id(&pos[opts_len], DHCP_MSG_SERVER_ID);
   opts_len += DHCP_OPT_CLV_HEADER + DHCP_OPT_LEN_4BYTE;
 
   //DHCP Options: subnet mask
@@ -810,7 +810,7 @@ dhcp_message *ACA_Dhcp_Server::_pack_dhcp_nak(dhcp_message *dhcpreq)
   opts_len += DHCP_OPT_CLV_HEADER + DHCP_OPT_LEN_1BYTE;
 
   //DHCP Options: server identifier
-  _pack_dhcp_opt_server_id(&pos[opts_len], DHCP_MSG_SERVER_ID); 
+  _pack_dhcp_opt_server_id(&pos[opts_len], DHCP_MSG_SERVER_ID);
   opts_len += DHCP_OPT_CLV_HEADER + DHCP_OPT_LEN_4BYTE;
 
   //DHCP Options: end
@@ -896,7 +896,7 @@ string ACA_Dhcp_Server::_serialize_dhcp_message(dhcp_message *dhcpmsg)
       sprintf(str, "%02x", dhcpmsg->options[i]); // end
       packet.append(str);
       break;
-    } 
+    }
     // type code
     sprintf(str, "%02x", dhcpmsg->options[i++]);
     packet.append(str);
@@ -908,14 +908,14 @@ string ACA_Dhcp_Server::_serialize_dhcp_message(dhcp_message *dhcpmsg)
   }
 
   // a byte contains two str char, we only need byte length
-  int len = packet.length() / 2; 
+  int len = packet.length() / 2;
   packet.insert(0, _serialize_dhcp_ip_header_message(dhcpmsg, len));
   return packet;
 }
 
 string ACA_Dhcp_Server::_serialize_dhcp_ip_header_message(dhcp_message *dhcpmsg, int dhcp_message_len)
 {
-//process udp header
+  //process udp header
   udphear udphdr;
   udphdr.srcIp = htonl(DHCP_MSG_IP_HEADER_SRC_IP);
   udphdr.dstIp = htonl(DHCP_MSG_IP_HEADER_DEST_IP);

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -328,11 +328,6 @@ int ACA_OVS_L3_Programmer::create_or_update_router(RouterConfiguration &current_
                          current_router_subnet_id.c_str());
             new_subnet_routing_tables[current_router_subnet_id] = new_subnet_routing_table_entry;
           }
-          ACA_LOG_DEBUG("After inserting subnet routing table entry for subnet: %s, printing out the contents:\n",
-                        current_router_subnet_id.c_str());
-          for (auto kv : new_subnet_routing_tables) {
-            ACA_LOG_DEBUG("subnet_id: %s\n", kv.first.c_str());
-          }
           subnet_info_found = true;
           break;
         }
@@ -353,20 +348,9 @@ int ACA_OVS_L3_Programmer::create_or_update_router(RouterConfiguration &current_
       // -----critical section ends-----
       ACA_LOG_INFO("Added router entry for router id %s\n", router_id.c_str());
     } else {
-      ACA_LOG_DEBUG("Using existing router entry for router id %s\n", router_id.c_str());
-      ACA_LOG_DEBUG("Let's print out what we have in router %s 's subnet routing table.\n",
-                    router_id);
-      for (auto kv : _routers_table[router_id]) {
-        ACA_LOG_DEBUG("subnet_id: %s\n", kv.first.c_str());
-      }
       _routers_table_mutex.lock();
       _routers_table[router_id] = new_subnet_routing_tables;
       _routers_table_mutex.unlock();
-      ACA_LOG_DEBUG("After updating, print out what we have in router %s 's subnet routing table.\n",
-                    router_id);
-      for (auto kv : _routers_table[router_id]) {
-        ACA_LOG_DEBUG("subnet_id: %s\n", kv.first.c_str());
-      }
     }
 
   } catch (const std::invalid_argument &e) {

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -732,6 +732,7 @@ int ACA_OVS_L3_Programmer::create_or_update_router(RouterConfiguration &current_
         } else {
           ACA_LOG_INFO("Using existing router subnet table entry for subnet id %s\n",
                        current_router_subnet_id.c_str());
+          new_subnet_routing_tables[current_router_subnet_id] = new_subnet_routing_table_entry;
         }
       } else {
         ACA_LOG_ERROR("Not able to find the info for router with subnet ID: %s.\n",

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -821,10 +821,6 @@ int ACA_OVS_L3_Programmer::create_or_update_l3_neighbor(
   for (auto router_it = _routers_table.begin();
        router_it != _routers_table.end(); router_it++) {
     ACA_LOG_DEBUG("router ID:%s\n ", router_it->first.c_str());
-    for (auto kv : router_it->second) {
-      ACA_LOG_INFO("[create_or_update_l3_neighbor] router ID: [%s], subnet routering table's subnet ID: [%s], subnet_id we're looking for: [%s]\n",
-                   router_it->first.c_str(), kv.first.c_str(), subnet_id.c_str());
-    }
     // try to see if the destination subnet GW is connected to the current router
     auto found_subnet = router_it->second.find(subnet_id);
 

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -753,6 +753,11 @@ int ACA_OVS_L3_Programmer::create_or_update_router(RouterConfiguration &current_
       ACA_LOG_INFO("Added router entry for router id %s\n", router_id.c_str());
     } else {
       ACA_LOG_INFO("Using existing router entry for router id %s\n", router_id.c_str());
+      // -----critical section starts-----
+      _routers_table_mutex.lock();
+      _routers_table[router_id] = new_subnet_routing_tables;
+      _routers_table_mutex.unlock();
+      // -----critical section ends-----
     }
 
   } catch (const std::invalid_argument &e) {

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -326,6 +326,7 @@ int ACA_OVS_L3_Programmer::create_or_update_router(RouterConfiguration &current_
           } else {
             ACA_LOG_INFO("Using existing router subnet table entry for subnet id %s\n",
                          current_router_subnet_id.c_str());
+            new_subnet_routing_tables[current_router_subnet_id] = new_subnet_routing_table_entry;
           }
 
           subnet_info_found = true;

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -839,9 +839,6 @@ int ACA_OVS_L3_Programmer::create_or_update_l3_neighbor(
       // for each other subnet connected to this router, create the routing rule
       for (auto subnet_it = router_it->second.begin();
            subnet_it != router_it->second.end(); subnet_it++) {
-        // ACA_LOG_INFO("[create_or_update_l3_neighbor] router ID: [%s], subnet routering table's subnet ID: [%s], subnet_id we're looking for: [%s]\n",
-        //              router_it->first.c_str(), subnet_it->first.c_str(),
-        //              subnet_id.c_str());
         if (subnet_it->first == subnet_id) {
           // for the destination subnet, add the neighbor port to track it
           neighbor_port_table_entry new_neighbor_port_table_entry;

--- a/src/ovs/aca_ovs_l3_programmer.cpp
+++ b/src/ovs/aca_ovs_l3_programmer.cpp
@@ -348,9 +348,11 @@ int ACA_OVS_L3_Programmer::create_or_update_router(RouterConfiguration &current_
       // -----critical section ends-----
       ACA_LOG_INFO("Added router entry for router id %s\n", router_id.c_str());
     } else {
+      // -----critical section starts-----
       _routers_table_mutex.lock();
       _routers_table[router_id] = new_subnet_routing_tables;
       _routers_table_mutex.unlock();
+      // -----critical section ends-----
     }
 
   } catch (const std::invalid_argument &e) {


### PR DESCRIPTION
The purpose of this PR is to update the subnet routing correctly.

We saw that, in the current code, if we're using an existing router subnet table entry and trying to update it, the entry stays the same after the "update" lines. So we decided to add some lines to ensure the updated entry is in the map.