### PR TITLE
Refactor ovs-bridges checking logic and improve logging

### DIFF
--- a/src/aca_main.cpp
+++ b/src/aca_main.cpp
@@ -218,8 +218,12 @@ int main(int argc, char *argv[])
           new std::thread(std::bind(&GoalStateProvisionerImpl::RunServer, g_grpc_server));
   g_grpc_server_thread->detach();
 
-  aca_ovs_l2_programmer::ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
-
+  rc = aca_ovs_l2_programmer::ACA_OVS_L2_Programmer::get_instance().setup_ovs_bridges_if_need();
+  if (rc == EXIT_FAILURE) {
+    ACA_LOG_ERROR("%s \n", "ACA is not able to create the bridges, please check your environment");
+    aca_cleanup();
+    return rc;
+  }
   // monitor br-int for dhcp request message
   ovs_monitor_brint_thread =
           new thread(bind(&ACA_OVS_Control::monitor,


### PR DESCRIPTION
This PR does the following:

1. Prints better log, when ACA has one of the needed bridges but doesn't have the other one (br-int and br-tun), so that user know what to do with invalid environment.
2. Refactored logic for ovs-bridge checking, so that it behaves correctly when `br-int` does NOT exist but `br-tun` exists. Closes #249 .
3. Replaces PR #230 