### PR TITLE
Added .Finish call for gRPC server

### DIFF
--- a/include/aca_grpc.h
+++ b/include/aca_grpc.h
@@ -58,7 +58,7 @@ class GoalStateProvisionerAsyncServer {
     AT the SENT state, a streaming call doesn't do anything; but a unary call deletes its own instance,
     since this call is already done.
     */
-    enum CallStatus { INIT, SENT };
+    enum CallStatus { INIT, SENT, DESTROY };
     CallStatus status_;
     CallType type_;
     grpc::ServerContext ctx_;

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -221,9 +221,9 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
       ACA_LOG_DEBUG("%s\n", "Nothing to do when a PushGoalStatesStream call in at SENT state");
       streamingCall->stream_.Finish(Status::OK, baseCall);
       streamingCall->gsOperationReply_.Clear();
-//       delete baseCall;
       break;
     default:
+      delete baseCall;
       break;
     }
   }

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -220,7 +220,8 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
       break;
     case AsyncGoalStateProvionerCallBase::CallStatus::SENT:
       ACA_LOG_DEBUG("%s\n", "Nothing to do when a PushGoalStatesStream call in at SENT state");
-      streamingCall->stream_.Finish(grpc::Status::OK, baseCall);
+      streamingCall->stream_.Finish(Status::OK, baseCall);
+      delete streamingCall;
       break;
     default:
       break;

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -221,7 +221,7 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
       ACA_LOG_DEBUG("%s\n", "Nothing to do when a PushGoalStatesStream call in at SENT state");
       streamingCall->stream_.Finish(Status::OK, baseCall);
       streamingCall->gsOperationReply_.Clear();
-      delete baseCall;
+//       delete baseCall;
       break;
     default:
       break;

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -218,15 +218,11 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
       }
       break;
     case AsyncGoalStateProvionerCallBase::CallStatus::SENT:
-      ACA_LOG_DEBUG("%s\n", "In SENT state, calling .Finish");
       streamingCall->status_ = AsyncGoalStateProvionerCallBase::CallStatus::DESTROY;
       streamingCall->stream_.Finish(Status::OK, baseCall);
       break;
     case AsyncGoalStateProvionerCallBase::CallStatus::DESTROY:
-      ACA_LOG_DEBUG("%s\n", "In DESTROY state, calling .Finish");
-      ACA_LOG_DEBUG("%s\n", "In DESTROY state, calling gsOperationReply_.Clear()");
       streamingCall->gsOperationReply_.Clear();
-      ACA_LOG_DEBUG("%s\n", "In DESTROY state, calling delete baseCall");
       delete (PushGoalStatesStreamAsyncCall *)baseCall;
       break;
     default:

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -220,7 +220,7 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
       break;
     case AsyncGoalStateProvionerCallBase::CallStatus::SENT:
       ACA_LOG_DEBUG("%s\n", "Nothing to do when a PushGoalStatesStream call in at SENT state");
-      streamingCall->stream_.Finish(Status::OK, baseCall);
+      streamingCall->stream_.Finish(Status::OK, static_cast<PushGoalStatesStreamAsyncCall *>(baseCall));
       delete streamingCall;
       break;
     default:

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -214,6 +214,7 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
           streamingCall->status_ = AsyncGoalStateProvionerCallBase::CallStatus::SENT;
           streamingCall->hasReadFromStream = false;
           streamingCall->stream_.Write(streamingCall->gsOperationReply_, baseCall);
+        //   this call will make ACA crash if we need to call the stream.Finish
         //   streamingCall->gsOperationReply_.Clear();
         }
       }
@@ -221,7 +222,6 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
     case AsyncGoalStateProvionerCallBase::CallStatus::SENT:
       ACA_LOG_DEBUG("%s\n", "Nothing to do when a PushGoalStatesStream call in at SENT state");
       streamingCall->stream_.Finish(Status::OK, baseCall);
-      streamingCall->gsOperationReply_.Clear();
       delete baseCall;
       break;
     default:

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -223,6 +223,7 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
 //       streamingCall->gsOperationReply_.Clear();
       break;
     default:
+      ACA_LOG_DEBUG("%s\n", "PushGoalStatesStream call in at DEFAULT state");
       delete baseCall;
       break;
     }

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -219,7 +219,11 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
       break;
     case AsyncGoalStateProvionerCallBase::CallStatus::SENT:
       ACA_LOG_DEBUG("%s\n", "In SENT state, calling .Finish");
+      streamingCall->status_ = AsyncGoalStateProvionerCallBase::CallStatus::DESTROY;
       streamingCall->stream_.Finish(Status::OK, baseCall);
+      break;
+    case AsyncGoalStateProvionerCallBase::CallStatus::DESTROY:
+      ACA_LOG_DEBUG("%s\n", "In DESTROY state, calling .Finish");
       ACA_LOG_DEBUG("%s\n", "In SENT state, calling gsOperationReply_.Clear()");
       streamingCall->gsOperationReply_.Clear();
       ACA_LOG_DEBUG("%s\n", "In SENT state, calling delete baseCall");

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -214,14 +214,14 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
           streamingCall->status_ = AsyncGoalStateProvionerCallBase::CallStatus::SENT;
           streamingCall->hasReadFromStream = false;
           streamingCall->stream_.Write(streamingCall->gsOperationReply_, baseCall);
-          streamingCall->gsOperationReply_.Clear();
+        //   streamingCall->gsOperationReply_.Clear();
         }
       }
       break;
     case AsyncGoalStateProvionerCallBase::CallStatus::SENT:
       ACA_LOG_DEBUG("%s\n", "Nothing to do when a PushGoalStatesStream call in at SENT state");
-      streamingCall->stream_.Finish(Status::OK, static_cast<PushGoalStatesStreamAsyncCall *>(baseCall));
-      delete streamingCall;
+      streamingCall->stream_.Finish(Status::OK, baseCall);
+      delete baseCall;
       break;
     default:
       break;

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -224,9 +224,9 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
       break;
     case AsyncGoalStateProvionerCallBase::CallStatus::DESTROY:
       ACA_LOG_DEBUG("%s\n", "In DESTROY state, calling .Finish");
-      ACA_LOG_DEBUG("%s\n", "In SENT state, calling gsOperationReply_.Clear()");
+      ACA_LOG_DEBUG("%s\n", "In DESTROY state, calling gsOperationReply_.Clear()");
       streamingCall->gsOperationReply_.Clear();
-      ACA_LOG_DEBUG("%s\n", "In SENT state, calling delete baseCall");
+      ACA_LOG_DEBUG("%s\n", "In DESTROY state, calling delete baseCall");
       delete (PushGoalStatesStreamAsyncCall *)baseCall;
       break;
     default:

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -214,14 +214,13 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
           streamingCall->status_ = AsyncGoalStateProvionerCallBase::CallStatus::SENT;
           streamingCall->hasReadFromStream = false;
           streamingCall->stream_.Write(streamingCall->gsOperationReply_, baseCall);
-        //   this call will make ACA crash if we need to call the stream.Finish
-        //   streamingCall->gsOperationReply_.Clear();
         }
       }
       break;
     case AsyncGoalStateProvionerCallBase::CallStatus::SENT:
       ACA_LOG_DEBUG("%s\n", "Nothing to do when a PushGoalStatesStream call in at SENT state");
       streamingCall->stream_.Finish(Status::OK, baseCall);
+      streamingCall->gsOperationReply_.Clear();
       delete baseCall;
       break;
     default:

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -218,13 +218,15 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
       }
       break;
     case AsyncGoalStateProvionerCallBase::CallStatus::SENT:
-      ACA_LOG_DEBUG("%s\n", "Nothing to do when a PushGoalStatesStream call in at SENT state");
+      ACA_LOG_DEBUG("%s\n", "In SENT state, calling .Finish");
       streamingCall->stream_.Finish(Status::OK, baseCall);
-//       streamingCall->gsOperationReply_.Clear();
+      ACA_LOG_DEBUG("%s\n", "In SENT state, calling gsOperationReply_.Clear()");
+      streamingCall->gsOperationReply_.Clear();
+      ACA_LOG_DEBUG("%s\n", "In SENT state, calling delete baseCall");
+      delete (PushGoalStatesStreamAsyncCall *)baseCall;
       break;
     default:
       ACA_LOG_DEBUG("%s\n", "PushGoalStatesStream call in at DEFAULT state");
-      delete baseCall;
       break;
     }
   }

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -220,7 +220,7 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
     case AsyncGoalStateProvionerCallBase::CallStatus::SENT:
       ACA_LOG_DEBUG("%s\n", "Nothing to do when a PushGoalStatesStream call in at SENT state");
       streamingCall->stream_.Finish(Status::OK, baseCall);
-      streamingCall->gsOperationReply_.Clear();
+//       streamingCall->gsOperationReply_.Clear();
       break;
     default:
       delete baseCall;

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -220,6 +220,7 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
       break;
     case AsyncGoalStateProvionerCallBase::CallStatus::SENT:
       ACA_LOG_DEBUG("%s\n", "Nothing to do when a PushGoalStatesStream call in at SENT state");
+      streamingCall->stream_.Finish(grpc::Status::OK, baseCall);
       break;
     default:
       break;

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -221,6 +221,7 @@ void GoalStateProvisionerAsyncServer::ProcessPushGoalStatesStreamAsyncCall(
     case AsyncGoalStateProvionerCallBase::CallStatus::SENT:
       ACA_LOG_DEBUG("%s\n", "Nothing to do when a PushGoalStatesStream call in at SENT state");
       streamingCall->stream_.Finish(Status::OK, baseCall);
+      streamingCall->gsOperationReply_.Clear();
       delete baseCall;
       break;
     default:


### PR DESCRIPTION
What this PR does:

- Added functionality to ACA's gRPC server, which notifies the client(NCM) a requetst is finished, meaning that the onCompleted() in a Java gRPC client will be invoked.


Note:
- In this async gRPC model, please note that each time when a `tag`(the request) is retrieved from the `CompletionQueue`, one and only one action shall be performed(such as read/write/finish/delete request object), if you perform multiple actions in one `CompletionQueue->Next`, the program may crash.