### PR TITLE
Add description of deprecated code path of ovs control, but also enable parse packet in it

### DIFF
--- a/src/ovs/ovs_control.cpp
+++ b/src/ovs/ovs_control.cpp
@@ -1013,10 +1013,10 @@ void OVS_Control::monitor_vconn(vconn *vconn, bool reply_to_echo_requests,
                                                      &buffer_idp, &continuation);
                     uint32_t in_port = pin.flow_metadata.flow.in_port.ofp_port;
                     /*
-            The pin.packet here has the same memory address, even after multiple calls.
-            If you intent to store it somewhere, it is advised to make a copy of it.
-          */
-                    // ACA_On_Demand_Engine::get_instance().parse_packet(in_port, pin.packet);
+                     The pin.packet here has the same memory address, even after multiple calls.
+                     If you intent to store it somewhere, it is advised to make a copy of it.
+                     */
+                    ACA_On_Demand_Engine::get_instance().parse_packet(in_port, pin.packet);
 
                     if (error) {
                         fprintf(stderr, "decoding packet-in failed: %s",

--- a/src/ovs/ovs_control.cpp
+++ b/src/ovs/ovs_control.cpp
@@ -15,12 +15,14 @@
 
 #include "aca_log.h"
 #include "aca_util.h"
-#include "ovs_control.h"
+#include "aca_on_demand_engine.h"
+
 #undef OFP_ASSERT
 #undef CONTAINER_OF
 #undef ARRAY_SIZE
 #undef ROUND_UP
-// #include "aca_on_demand_engine.h"
+#include "ovs_control.h"
+
 #include <sstream> // std::(istringstream)
 #include <string> // std::(string)
 #include <signal.h>
@@ -45,7 +47,7 @@
 #include <openvswitch/vlog.h>
 
 using namespace std;
-// using namespace aca_on_demand_engine;
+using namespace aca_on_demand_engine;
 
 extern std::atomic_ulong g_total_execute_openflow_time;
 

--- a/src/ovs/ovs_control.cpp
+++ b/src/ovs/ovs_control.cpp
@@ -15,7 +15,7 @@
 
 /*
  This file is legacy code path, that we used vconn from ovs code to connect and manipulate ovs by the same way of ovs cmd tools
- From 10/30/2021 release, ovs connection and events/flows manipulation are already handled by of_controller.cpp
+ From 9/30/2021 release, ovs connection and events/flows manipulation are already handled by of_controller.cpp
  We leave this legacy file for reference
  */
 

--- a/src/ovs/ovs_control.cpp
+++ b/src/ovs/ovs_control.cpp
@@ -13,6 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/*
+ This file is legacy code path, that we used vconn from ovs code to connect and manipulate ovs by the same way of ovs cmd tools
+ From 10/30/2021 release, ovs connection and events/flows manipulation are already handled by of_controller.cpp
+ We leave this legacy file for reference
+ */
+
 #include "aca_log.h"
 #include "aca_util.h"
 #include "aca_on_demand_engine.h"


### PR DESCRIPTION
1. Uncomment parse packet in ovs control vconn code path
2. Fix redefinition of header files in ovs control
3. Add description of ovs_control code path being legacy and deprecated